### PR TITLE
Some fixes

### DIFF
--- a/core/v0/api/core.json
+++ b/core/v0/api/core.json
@@ -2218,27 +2218,21 @@
                         "$ref": "#/components/schemas/Time"
                     },
                     "tags": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Tags"
-                        }
+                        "$ref": "#/components/schemas/Tags"
                     }
                 }
             },
             "Circle": {
                 "description": "Describes a circular area on the map",
-                "allOf": [
-                    {
+                "type": "object",
+                "properties": {
+                    "gps": {
                         "$ref": "#/components/schemas/Gps"
                     },
-                    {
-                        "properties": {
-                            "radius": {
-                                "$ref": "#/components/schemas/Scalar"
-                            }
-                        }
+                    "radius": {
+                        "$ref": "#/components/schemas/Scalar"
                     }
-                ]
+                }
             },
             "City": {
                 "description": "Describes a city",
@@ -2608,10 +2602,7 @@
                         "type": "string"
                     },
                     "tags": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Tags"
-                        }
+                        "$ref": "#/components/schemas/Tags"
                     }
                 }
             },
@@ -2763,10 +2754,7 @@
                         "type": "string"
                     },
                     "tags": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Tags"
-                        }
+                        "$ref": "#/components/schemas/Tags"
                     }
                 }
             },
@@ -2864,10 +2852,7 @@
                         "$ref": "#/components/schemas/Time"
                     },
                     "tags": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Tags"
-                        }
+                        "$ref": "#/components/schemas/Tags"
                     }
                 }
             },
@@ -2996,37 +2981,30 @@
                 }
             },
             "Operator": {
-                "description": "Describes an offer",
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
+                "description": "Describes the agent of a service",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Person"
                     },
-                    "descriptor": {
-                        "$ref": "#/components/schemas/Descriptor"
-                    },
-                    "location_ids": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Location/properties/id"
+                    {
+                        "properties": {
+                            "experience": {
+                                "type": "object",
+                                "properties": {
+                                    "label": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    },
+                                    "unit": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         }
-                    },
-                    "category_ids": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Category/properties/id"
-                        }
-                    },
-                    "item_ids": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Item/properties/id"
-                        }
-                    },
-                    "time": {
-                        "$ref": "#/components/schemas/Time"
                     }
-                }
+                ]
             },
             "Option": {
                 "description": "Describes a selectable option",
@@ -3268,10 +3246,7 @@
                         "type": "string"
                     },
                     "tags": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Tags"
-                        }
+                        "$ref": "#/components/schemas/Tags"
                     }
                 }
             },
@@ -3402,10 +3377,7 @@
                         }
                     },
                     "tags": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Tags"
-                        }
+                        "$ref": "#/components/schemas/Tags"
                     }
                 }
             },
@@ -3635,10 +3607,7 @@
                         "type": "string"
                     },
                     "channels": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Tags"
-                        }
+                        "$ref": "#/components/schemas/Tags"
                     }
                 }
             },

--- a/core/v0/api/core.yaml
+++ b/core/v0/api/core.yaml
@@ -1437,11 +1437,13 @@ components:
 
     Circle:
       description: Describes a circular area on the map
-      allOf:
-        - $ref: "#/components/schemas/Gps"
-        - properties:
-            radius:
-              $ref: "#/components/schemas/Scalar"
+      type: object
+      properties:
+        gps:
+          $ref: "#/components/schemas/Gps"
+        radius:
+          $ref: "#/components/schemas/Scalar"
+
     City:
       description: Describes a city
       type: object

--- a/core/v0/api/core.yaml
+++ b/core/v0/api/core.yaml
@@ -1431,9 +1431,7 @@ components:
         time:
           $ref: "#/components/schemas/Time"
         tags:
-          type: array
-          items:
-            $ref: "#/components/schemas/Tags"
+          $ref: "#/components/schemas/Tags"
 
     Circle:
       description: Describes a circular area on the map
@@ -1718,9 +1716,7 @@ components:
         purpose:
           type: string
         tags:
-          type: array
-          items:
-            $ref: "#/components/schemas/Tags"
+          $ref: "#/components/schemas/Tags"
     Gps:
       description: Describes a gps coordinate
       type: string
@@ -1819,9 +1815,7 @@ components:
         purpose:
           type: string
         tags:
-          type: array
-          items:
-            $ref: "#/components/schemas/Tags"
+          $ref: "#/components/schemas/Tags"
 
     ItemQuantity:
       description: Describes count or amount of an item
@@ -1888,9 +1882,7 @@ components:
         time:
           $ref: "#/components/schemas/Time"
         tags:
-          type: array
-          items:
-            $ref: "#/components/schemas/Tags"
+          $ref: "#/components/schemas/Tags"
     Language:
       description: indicates language code. Beckn supports country codes as per ISO 639.2 standard
       type: object
@@ -2158,9 +2150,7 @@ components:
         cred:
           type: string
         tags:
-          type: array
-          items:
-            $ref: "#/components/schemas/Tags"
+          $ref: "#/components/schemas/Tags"
 
     Policy:
       description: Describes a policy. Allows for domain extension.
@@ -2245,9 +2235,7 @@ components:
           items:
             $ref: "#/components/schemas/Location"
         tags:
-          type: array
-          items:
-            $ref: "#/components/schemas/Tags"
+          $ref: "#/components/schemas/Tags"
 
     Quotation:
       description: Describes a quote
@@ -2416,9 +2404,7 @@ components:
         ref_id:
           type: string
         channels:
-          type: array
-          items:
-            $ref: "#/components/schemas/Tags"
+          $ref: "#/components/schemas/Tags"
 
     Tags:
       description: Describes a tag. This is a simple key-value store which is used to contain extended metadata

--- a/core/v0/api/core.yaml
+++ b/core/v0/api/core.yaml
@@ -1981,27 +1981,19 @@ components:
           $ref: "#/components/schemas/Time"
 
     Operator:
-      description: Describes an offer
-      type: object
-      properties:
-        id:
-          type: string
-        descriptor:
-          $ref: "#/components/schemas/Descriptor"
-        location_ids:
-          type: array
-          items:
-            $ref: "#/components/schemas/Location/properties/id"
-        category_ids:
-          type: array
-          items:
-            $ref: "#/components/schemas/Category/properties/id"
-        item_ids:
-          type: array
-          items:
-            $ref: "#/components/schemas/Item/properties/id"
-        time:
-          $ref: "#/components/schemas/Time"
+      description: Describes the agent of a service
+      allOf:
+        - $ref: "#/components/schemas/Person"
+        - properties:
+            experience:
+              type: object
+              properties:
+                label:
+                  type: string
+                value:
+                  type: string
+                unit:
+                  type: string
 
     Option:
       description: Describes a selectable option


### PR DESCRIPTION
1. Fixed unclear `Circle` definition. (It is impossible to merge a string and an object via `allOf`)
2. `Operator` definition is actually just a copy of the `Offer` definition. I am not sure what the correct definition should look like, because core/v0/schema/operator.json is not completely correct at the moment, so I made my best guess.
3. Since `Tags` is a single object with many tags, there's no need to wrap it with array
