### PR TITLE
[WIP] Refactor Location and Address

### DIFF
--- a/core/v0/api/core.json
+++ b/core/v0/api/core.json
@@ -1847,16 +1847,17 @@
                         "description": "Name or number of the ward if applicable"
                     },
                     "city": {
-                        "type": "string",
-                        "description": "City name"
+                        "$ref": "#/components/schemas/City"
                     },
                     "state": {
                         "type": "string",
                         "description": "State name"
                     },
                     "country": {
-                        "type": "string",
-                        "description": "Country name"
+                        "$ref": "#/components/schemas/Country"
+                    },
+                    "station_code": {
+                        "type": "string"
                     },
                     "area_code": {
                         "type": "string",
@@ -2656,29 +2657,59 @@
                     "descriptor": {
                         "$ref": "#/components/schemas/Descriptor"
                     },
-                    "gps": {
-                        "$ref": "#/components/schemas/Gps"
-                    },
-                    "address": {
-                        "$ref": "#/components/schemas/Address"
-                    },
-                    "station_code": {
-                        "type": "string"
-                    },
-                    "city": {
-                        "$ref": "#/components/schemas/City"
-                    },
-                    "country": {
-                        "$ref": "#/components/schemas/Country"
-                    },
-                    "circle": {
-                        "$ref": "#/components/schemas/Circle"
-                    },
-                    "polygon": {
-                        "type": "string"
-                    },
-                    "3dspace": {
-                        "type": "string"
+                    "location": {
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "gps": {
+                                        "$ref": "#/components/schemas/Gps"
+                                    }
+                                },
+                                "required": [
+                                    "gps"
+                                ]
+                            },
+                            {
+                                "properties": {
+                                    "address": {
+                                        "$ref": "#/components/schemas/Address"
+                                    }
+                                },
+                                "required": [
+                                    "address"
+                                ]
+                            },
+                            {
+                                "properties": {
+                                    "circle": {
+                                        "$ref": "#/components/schemas/Circle"
+                                    }
+                                },
+                                "required": [
+                                    "circle"
+                                ]
+                            },
+                            {
+                                "properties": {
+                                    "polygon": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "polygon"
+                                ]
+                            },
+                            {
+                                "properties": {
+                                    "3dspace": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "3dspace"
+                                ]
+                            }
+                        ]
                     }
                 }
             },
@@ -3461,7 +3492,7 @@
             },
             "TrackingData": {
                 "description": "Describes tracking data object during live tracking of an order",
-                "$ref": "#/components/schemas/Location/properties/gps"
+                "$ref": "#/components/schemas/Gps"
             },
             "Tracking": {
                 "description": "Describes the tracking info of an object",

--- a/core/v0/api/core.yaml
+++ b/core/v0/api/core.yaml
@@ -1169,14 +1169,14 @@ components:
           type: string
           description: Name or number of the ward if applicable
         city:
-          type: string
-          description: City name
+          $ref: '#/components/schemas/City'
         state:
           type: string
           description: State name
         country:
+          $ref: '#/components/schemas/Country'
+        station_code:
           type: string
-          description: Country name
         area_code:
           type: string
           description: 'Area code. This can be Pincode, ZIP code or any equivalent'
@@ -1737,22 +1737,33 @@ components:
           type: string
         descriptor:
           $ref: '#/components/schemas/Descriptor'
-        gps:
-          $ref: '#/components/schemas/Gps'
-        address:
-          $ref: '#/components/schemas/Address'
-        station_code:
-          type: string
-        city:
-          $ref: '#/components/schemas/City'
-        country:
-          $ref: '#/components/schemas/Country'
-        circle:
-          $ref: '#/components/schemas/Circle'
-        polygon:
-          type: string
-        3dspace:
-          type: string
+        location:
+          oneOf:
+            - properties:
+                gps: 
+                  $ref: '#/components/schemas/Gps'
+              required:
+                - gps
+            - properties:
+                address:
+                  $ref: '#/components/schemas/Address'
+              required: 
+                - address
+            - properties:
+                circle:
+                  $ref: '#/components/schemas/Circle'
+              required:
+                - circle
+            - properties:
+                polygon:
+                  type: string
+              required:
+                - polygon
+            - properties:
+                3dspace:
+                  type: string
+              required:
+                - 3dspace
           
     MonetaryValue:
       description: Describes a monetary value used for exchange
@@ -2300,7 +2311,7 @@ components:
     
     TrackingData:
       description: Describes tracking data object during live tracking of an order
-      $ref: '#/components/schemas/Location/properties/gps'
+      $ref: '#/components/schemas/Gps'
     
     Tracking:
       description: Describes the tracking info of an object


### PR DESCRIPTION
* Refactored location to object-with-single-field sum type encoding 
* Move `city` and `country` fields from location to address where they should belong

How `id` and `descriptor` field should be used in `Location` type? Should we add them as variants as `address`, `gps`, `polygon`?