### PR TITLE
added supported_actions field in Context schema

### DIFF
--- a/core/v0/api/core.json
+++ b/core/v0/api/core.json
@@ -2300,6 +2300,10 @@
                             "ack"
                         ]
                     },
+                    "supported_actions": {
+                        "type": "string",
+                        "description": "Describes which actions this participant supports. For BAP these are initial requests, e. g. \"search,select,init...\", for BPP string should look like \"on_search,on_select...\"."
+                    },
                     "core_version": {
                         "type": "string",
                         "description": "Version of Beckn core API specification being used"

--- a/core/v0/api/core.yaml
+++ b/core/v0/api/core.yaml
@@ -1481,6 +1481,9 @@ components:
             - on_feedback
             - on_support
             - ack
+        supported_actions:
+          type: string
+          description: Describes which actions this participant supports. For BAP these are initial requests, e. g. "search,select,init...", for BPP string should look like "on_search,on_select...".
         core_version:
           type: string
           description: Version of Beckn core API specification being used


### PR DESCRIPTION
As discussed this PR adds field "supported_actions" that describes which actions this participant supports.
This idea still under discussion, any thoughts appreciated.