### PR TITLE
Revert "make gps field of Location required"

### DIFF
--- a/core/v0/api/core.json
+++ b/core/v0/api/core.json
@@ -2814,10 +2814,7 @@
                     "3dspace": {
                         "type": "string"
                     }
-                },
-                "required": [
-                    "gps"
-                ]
+                }
             },
             "MonetaryValue": {
                 "description": "Describes a monetary value used for exchange",

--- a/core/v0/api/core.yaml
+++ b/core/v0/api/core.yaml
@@ -1847,8 +1847,6 @@ components:
           type: string
         3dspace:
           type: string
-      required:
-        - gps
           
     MonetaryValue:
       description: Describes a monetary value used for exchange


### PR DESCRIPTION
After Ravi's explanation of Location schema it got clear that gps field of Location schema shouldn't be required.

This reverts commit f2973d15835fc7dc3e8ac3dfd114a836173a39a9.