### PR TITLE
Meta APIs made async

### DIFF
--- a/core/v0/api/core.yaml
+++ b/core/v0/api/core.yaml
@@ -1043,7 +1043,7 @@ paths:
     post:
       tags:
         - BPP Meta APIs
-      description: Look up subscriber(s) in a registry
+      description: Get cancellation reasons from the BPP
       requestBody:
         description: TODO
         content:
@@ -1056,15 +1056,58 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                   $ref: '#/components/schemas/Option'
+                type: object
+                properties:
+                  message:
+                    type: object
+                    properties:
+                      ack:
+                        $ref: '#/components/schemas/Ack'
+                    required:
+                      - ack
+                  error:
+                    $ref: '#/components/schemas/Error'
+                required:
+                  - message
+
+  /cancellation_reasons:
+    post:
+      tags:
+        - BAP Meta APIs
+      description: Get cancellation reasons from the BPP
+      requestBody:
+        description: TODO
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                  $ref: '#/components/schemas/Option'
+      responses:
+        '200':
+          description: List of cancellation reasons
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: object
+                    properties:
+                      ack:
+                        $ref: '#/components/schemas/Ack'
+                    required:
+                      - ack
+                  error:
+                    $ref: '#/components/schemas/Error'
+                required:
+                  - message
 
   /get_return_reasons:
     post:
       tags:
         - BPP Meta APIs
-      description: Look up subscriber(s) in a registry
+      description: Get return reasons from the BPP
       requestBody:
         description: TODO
         content:
@@ -1077,9 +1120,52 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                   $ref: '#/components/schemas/Option'
+                type: object
+                properties:
+                  message:
+                    type: object
+                    properties:
+                      ack:
+                        $ref: '#/components/schemas/Ack'
+                    required:
+                      - ack
+                  error:
+                    $ref: '#/components/schemas/Error'
+                required:
+                  - message
+
+  /return_reasons:
+    post:
+      tags:
+        - BAP Meta APIs
+      description: Get return reasons from the BPP
+      requestBody:
+        description: TODO
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                  $ref: '#/components/schemas/Option'
+      responses:
+        '200':
+          description: List of return reasons
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: object
+                    properties:
+                      ack:
+                        $ref: '#/components/schemas/Ack'
+                    required:
+                      - ack
+                  error:
+                    $ref: '#/components/schemas/Error'
+                required:
+                  - message
 
   /get_rating_categories:
     post:
@@ -1098,14 +1184,57 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  allOf:
-                  - $ref: '#/components/schemas/Category'
-                  - type: object
+                type: object
+                properties:
+                  message:
+                    type: object
                     properties:
-                      question:
-                        type: string
+                      ack:
+                        $ref: '#/components/schemas/Ack'
+                    required:
+                      - ack
+                  error:
+                    $ref: '#/components/schemas/Error'
+                required:
+                  - message
+
+  /rating_categories:
+    post:
+      tags:
+        - BAP Meta APIs
+      description: Get a list of feedback forms based on rating inputs
+      requestBody:
+        description: TODO
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                allOf:
+                - $ref: '#/components/schemas/Category'
+                - type: object
+                  properties:
+                    question:
+                      type: string
+      responses:
+        '200':
+          description: Feedback forms
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: object
+                    properties:
+                      ack:
+                        $ref: '#/components/schemas/Ack'
+                    required:
+                      - ack
+                  error:
+                    $ref: '#/components/schemas/Error'
+                required:
+                  - message
 
 
 components:

--- a/core/v0/api/core.yaml
+++ b/core/v0/api/core.yaml
@@ -1079,14 +1079,17 @@ paths:
         - BPP Meta APIs
       description: Get cancellation reasons from the BPP
       requestBody:
-        description: TODO
+        description: Context header is sent as the request
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Context'
+              type: object
+              properties:
+                context:
+                  $ref: '#/components/schemas/Context'
       responses:
         '200':
-          description: List of cancellation reasons
+          description: Acknowledgement of message received
           content:
             application/json:
               schema:
@@ -1110,16 +1113,24 @@ paths:
         - BAP Meta APIs
       description: Get cancellation reasons from the BPP
       requestBody:
-        description: TODO
+        description: List of cancellation reasons
         content:
           application/json:
             schema:
-              type: array
-              items:
-                  $ref: '#/components/schemas/Option'
+              type: object
+              properties:
+                context:
+                    $ref: '#/components/schemas/Context'
+                message:
+                  type: object
+                  properties:
+                    cancellation_reasons:
+                      type: array
+                      items:
+                          $ref: '#/components/schemas/Option'
       responses:
         '200':
-          description: List of cancellation reasons
+          description: Acknowledgement of message received
           content:
             application/json:
               schema:
@@ -1143,14 +1154,17 @@ paths:
         - BPP Meta APIs
       description: Get return reasons from the BPP
       requestBody:
-        description: TODO
+        description: Context header is sent as the request
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Context'
+              type: object
+              properties:
+                context:
+                  $ref: '#/components/schemas/Context'
       responses:
         '200':
-          description: List of return reasons
+          description: Acknowledgement of message received
           content:
             application/json:
               schema:
@@ -1174,16 +1188,21 @@ paths:
         - BAP Meta APIs
       description: Get return reasons from the BPP
       requestBody:
-        description: TODO
+        description: List of return reasons
         content:
           application/json:
             schema:
-              type: array
-              items:
-                  $ref: '#/components/schemas/Option'
+              type: object
+              properties:
+                context:
+                    $ref: '#/components/schemas/Context'
+                return_reasons:
+                  type: array
+                  items:
+                      $ref: '#/components/schemas/Option'
       responses:
         '200':
-          description: List of return reasons
+          description: Acknowledgement of message received
           content:
             application/json:
               schema:
@@ -1211,10 +1230,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Context'
+              type: object
+              properties:
+                context:
+                    $ref: '#/components/schemas/Context'
       responses:
         '200':
-          description: Array of categories which can be rated
+          description: Acknowledgement of message received
           content:
             application/json:
               schema:
@@ -1238,16 +1260,21 @@ paths:
         - BAP Meta APIs
       description: Get a list of categories that can be rated by the BAP
       requestBody:
-        description: Context header is sent as the request
+        description: Array of categories which can be rated
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/Rating/properties/rating_category'
+              type: object
+              properties:
+                context:
+                    $ref: '#/components/schemas/Context'
+                rating_categories:  
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Rating/properties/rating_category'
       responses:
         '200':
-          description: Array of categories which can be rated
+          description: Acknowledgement of message received
           content:
             application/json:
               schema:
@@ -1275,10 +1302,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Context'
+              type: object
+              properties:
+                context:
+                    $ref: '#/components/schemas/Context'
       responses:
         '200':
-          description: Array of categories for which feedback can be given by the BAP
+          description: Acknowledgement of message received
           content:
             application/json:
               schema:
@@ -1302,16 +1332,21 @@ paths:
         - BAP Meta APIs
       description: Get a list of categories for which feedback can be given by the BAP
       requestBody:
-        description: Context header is sent as the request
+        description: Array of categories for which feedback can be given by the BAP
         content:
           application/json:
             schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Rating/properties/rating_category'
+              type: object
+              properties:
+                context:
+                    $ref: '#/components/schemas/Context'
+                feedback_categories:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Rating/properties/rating_category'
       responses:
         '200':
-          description: Array of categories for which feedback can be given by the BAP
+          description: Acknowledgement of message received
           content:
             application/json:
               schema:
@@ -1352,7 +1387,7 @@ paths:
                       $ref: '#/components/schemas/Rating/properties/rating_category'
       responses:
         '200':
-          description: Array of categories for which feedback can be given by the BAP
+          description: Acknowledgement of message received
           content:
             application/json:
               schema:
@@ -1376,7 +1411,7 @@ paths:
         - BAP Meta APIs
       description: Get a feedback form from the BPP
       requestBody:
-        description: The rating value and category is sent by the BAP
+        description: Feedback form sent by the BPP 
         content:
           application/json:
             schema:
@@ -1389,7 +1424,7 @@ paths:
 
       responses:
         '200':
-          description: Array of categories for which feedback can be given by the BAP
+          description: Acknowledgement of message received
           content:
             application/json:
               schema:


### PR DESCRIPTION
Made the following BPP meta APIs async : 
- POST /get_cancellation_reasons
- ​POST /get_return_reasons
- ​POST /get_rating_categories

Which would use the following newly created BAP meta APIs :
- ​POST /cancellation_reasons
- ​POST /return_reasons
- ​POST /rating_categories