### PR TITLE
BG Authentication Transition Spec from Proxy-Authorization to X-Gateway-Authorization

### DIFF
--- a/core/v0/api/core.yaml
+++ b/core/v0/api/core.yaml
@@ -7,6 +7,7 @@ info:
 security:
   - SubscriberAuth: []
   - GatewaySubscriberAuth: []
+  - GatewaySubscriberAuthNew: []
 paths:
   /search:
     post:
@@ -1425,6 +1426,11 @@ components:
       name: Authorization
       description: 'Signature of message body using BAP or BPP subscriber''s signing public key. <br/><br/>Format:<br/><br/><code>Authorization : Signature keyId="{subscriber_id}|{unique_key_id}|{algorithm}",algorithm="ed25519",created="1606970629",expires="1607030629",headers="(created) (expires) digest",signature="Base64(BLAKE-512(signing string))"</code>'
     GatewaySubscriberAuth:
+      type: apiKey
+      in: header
+      name: Proxy-Authorization
+      description: 'Signature of message body + BAP/BPP''s Authorization header using BG''s signing public key. Format:<br/><br/><code>X-Gateway-Authorization : Signature keyId="{subscriber_id}|{unique_key_id}|{algorithm}",algorithm="ed25519",created="1606970629",expires="1607030629",headers="(created) (expires) digest",signature="Base64(BLAKE-512(signing string))"</code><p><b>Note:</b>This header will be deprecated soon and will no longer be supported in future releases. New implementors are requested to use the X-Gateway-Authorization header. Existing implementations are requested to migrate their header to the new header. The deprecation date will be set after discussion as per the standard specification governance process.</p>'
+    GatewaySubscriberAuthNew:
       type: apiKey
       in: header
       name: X-Gateway-Authorization


### PR DESCRIPTION
Adding a new security scheme for BGs called X-Gateway-Authorization. The old scheme `Proxy-Authorization` will be deprecated soon. To allow implementors time to migrate, Both security schemes will be supported. All BGs are expected to add both headers `Proxy-Authorization` and `X-Gateway-Authorization` in the `search` multicast API call. BAPs and BPPs can use either of the headers to authenticate the BG.  