### PR TITLE
Solution for Issue #243

### DIFF
--- a/core/v0/api/core.yaml
+++ b/core/v0/api/core.yaml
@@ -1950,7 +1950,6 @@ components:
         id:
           description: This is the most unique identifier of a service item. An example of an Item ID could be the SKU of a product.
           type: string
-          format: '#/components/schemas/Item/properties/id'
         parent_item_id:
           $ref: '#/components/schemas/Item/properties/id'
         descriptor:


### PR DESCRIPTION
In order to resolve the issue with the `id` property of the `Item` present inside the components, the format specification is removed. It's valid as per the `type: string`.