### PR TITLE
Updating Customer and Support schema to add new properties

### DIFF
--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1016,6 +1016,8 @@ components:
       properties:
         person:
           $ref: '#/components/schemas/Person'
+        organization:
+          $ref: '#/components/schemas/Organization'
         contact:
           $ref: '#/components/schemas/Contact'
     DecimalValue:

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1014,6 +1014,9 @@ components:
       description: Describes a customer buying/availing a product or a service
       type: object
       properties:
+        id:
+          description: ID of the customer.
+          type: string
         person:
           $ref: '#/components/schemas/Person'
         organization:
@@ -2032,7 +2035,7 @@ components:
       description: Details of customer support
       type: object
       properties:
-        ref_id:
+        order_id:
           type: string
         callback_phone:
           type: string

--- a/docs/BECKN-001-Layering-Network-Policy-Draft-01.md
+++ b/docs/BECKN-001-Layering-Network-Policy-Draft-01.md
@@ -312,6 +312,8 @@ FulfillmentPolicy1:
       properties:
         person:
           $ref: '#/components/schemas/Person'
+        organization:
+          $ref: '#/components/schemas/Organization'
         contact:
           $ref: '#/components/schemas/Contact'
     agent:

--- a/docs/BECKN-001-Layering-Network-Policy-Draft-01.md
+++ b/docs/BECKN-001-Layering-Network-Policy-Draft-01.md
@@ -310,6 +310,9 @@ FulfillmentPolicy1:
     customer:
       type: object
       properties:
+        id:
+          description: ID of the customer.
+          type: string
         person:
           $ref: '#/components/schemas/Person'
         organization:

--- a/schema/Support.yaml
+++ b/schema/Support.yaml
@@ -1,7 +1,7 @@
 description: Details of customer support
 type: object
 properties:
-  ref_id:
+  order_id:
     type: string
   callback_phone:
     type: string


### PR DESCRIPTION
Changes include
- Updating Customer schema to include an ID property that will be used to identify a customer
- Updating Customer schema to include the organization property that is a reference to the Organization schema.
- Updating the Support schema to modify the `ref_id` property to `order_id`