### PR TITLE
separating the cred and on_cred underlying schema objects

### DIFF
--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -389,12 +389,12 @@ paths:
                 message:
                   type: object
                   properties:
-                    creds:
+                    proofs:
                       type: array
                       items:
-                        $ref: '#/components/schemas/Credential'
+                        $ref: '#/components/schemas/CredentialRequest'
                   required:
-                    - creds
+                    - proofs
               required:
                 - context
                 - message
@@ -762,12 +762,12 @@ paths:
                 message:
                   type: object
                   properties:
-                    creds:
+                    proofs:
                       type: array
                       items:
                         $ref: '#/components/schemas/Credential'
                   required:
-                    - creds
+                    - proofs
                 error:
                   $ref: '#/components/schemas/Error'
               required:
@@ -1076,19 +1076,6 @@ components:
       properties:
         description:
           $ref: '#/components/schemas/Descriptor'
-        credential_category:
-          type: string
-          enum:
-            - AGENT
-            - CUSTOMER
-            - ORGANIZATION
-            - PAYMENT
-            - PROVIDER
-            - SUBSCRIBER
-            - FULFILLMENT
-            - ITEM
-            - ORDER
-            - PERSON
         docs:
           description: The Documents associated with the credential.
           type: array
@@ -1103,11 +1090,24 @@ components:
           description: URL of the credential
           type: string
           format: uri
-        xinput:
-          description: A BAP can send a form which can be filled by the BAP with relevant details.
-          $ref: '#/components/schemas/XInput'
         vc:
           $ref: '#/components/schemas/VC'
+    CredentialRequest:
+      description: Describes the schema used to request for a proof from an entity
+      type: object
+      properties:
+        description:
+          $ref: '#/components/schemas/Descriptor'
+        credential_purpose:
+          type: object
+          properties:
+            purpose:
+              type: string
+            document_examples:
+              type: string
+        xinput:
+          description: A requester can send a form which can be filled by the sender with relevant details.
+          $ref: '#/components/schemas/XInput'
     Customer:
       description: Describes a customer buying/availing a product or a service
       type: object

--- a/api/transaction/components/io/Cred.yaml
+++ b/api/transaction/components/io/Cred.yaml
@@ -12,12 +12,12 @@ properties:
   message:
     type: object
     properties:
-      creds:
+      proofs:
         type: array
         items:
-          $ref: "../../../../schema/Credential.yaml"
+          $ref: "../../../../schema/CredentialRequest.yaml"
     required:
-      - creds
+      - proofs
 required:
   - context
   - message

--- a/api/transaction/components/io/OnCred.yaml
+++ b/api/transaction/components/io/OnCred.yaml
@@ -12,12 +12,12 @@ properties:
   message:
     type: object
     properties:
-      creds:
+      proofs:
         type: array
         items:
           $ref: "../../../../schema/Credential.yaml"
     required:
-      - creds
+      - proofs
   error:
     $ref: "../../../../schema/Error.yaml"
 required:

--- a/api/transaction/components/schema/index.yaml
+++ b/api/transaction/components/schema/index.yaml
@@ -46,6 +46,9 @@ Country:
 Credential:
   $ref: "../../../../schema/Credential.yaml"
 
+CredentialRequest:
+  $ref: "../../../../schema/CredentialRequest.yaml"
+
 Customer:
   $ref: "../../../../schema/Customer.yaml"
 

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -3,19 +3,6 @@ type: object
 properties:
   description:
     $ref: "./Descriptor.yaml"
-  credential_category:
-    type: string
-    enum:
-      - AGENT
-      - CUSTOMER
-      - ORGANIZATION
-      - PAYMENT
-      - PROVIDER
-      - SUBSCRIBER
-      - FULFILLMENT
-      - ITEM
-      - ORDER
-      - PERSON
   docs:
     description: The Documents associated with the credential.
     type: array
@@ -30,9 +17,6 @@ properties:
     description: URL of the credential
     type: string
     format: uri
-  xinput:
-    description: A BAP can send a form which can be filled by the BAP with relevant details.
-    $ref: "./XInput.yaml"
   vc:
     $ref: "./VC.yaml"
 

--- a/schema/CredentialRequest.yaml
+++ b/schema/CredentialRequest.yaml
@@ -1,0 +1,23 @@
+description: Describes the schema used to request for a proof from an entity
+type: object
+properties:
+  description:
+    $ref: "./Descriptor.yaml"
+  credential_purpose:
+    type: object
+    properties:
+      purpose:
+        type: string
+        # enum:
+        #   - PROOF_OF_ADDRESS
+        #   - PROOF_OF_IDENTITY
+        #   - PROOF_OF_OWNERSHIP
+        #   - PROOF_OF_INCOME
+        #   - PROOF_OF_EDUCATION
+        #   - PROOF_OF_COMPLIANCE
+        #   - PROOF_OF_INSURANCE
+      document_examples:
+        type: string
+  xinput:
+    description: A requester can send a form which can be filled by the sender with relevant details.
+    $ref: "./XInput.yaml"


### PR DESCRIPTION
Created a new schema for the cred/ endpoint. 

The motivation is that we want to keep the schema of  cred/ very simple. Keep the request purpose specific, i.e. need a proof of identity, possible documents can be  a Passport, Driving Licence etc.