### PR TITLE
Hyperbeckn changes: Adding Evidence field in the credential schema

### DIFF
--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1096,13 +1096,11 @@ components:
       description: Describes the schema used to request for a proof from an entity
       type: object
       properties:
-        description:
-          $ref: '#/components/schemas/Descriptor'
         credential_purpose:
           type: object
           properties:
             purpose:
-              type: string
+              $ref: '#/components/schemas/Descriptor'
             document_examples:
               type: string
         xinput:

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -2403,10 +2403,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TagGroup'
-        status:
+        credentialStatus:
           type: array
           items:
             $ref: '#/components/schemas/Descriptor'
+        evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
     Vehicle:
       description: 'Describes a vehicle is a device that is designed or used to transport people or cargo over land, water, air, or through space.<br>This has properties like category, capacity, make, model, size,variant,color,energy_type,registration'
       type: object

--- a/schema/CredentialRequest.yaml
+++ b/schema/CredentialRequest.yaml
@@ -1,21 +1,11 @@
 description: Describes the schema used to request for a proof from an entity
 type: object
-properties:
-  description:
-    $ref: "./Descriptor.yaml"
+properties:    
   credential_purpose:
     type: object
     properties:
       purpose:
-        type: string
-        # enum:
-        #   - PROOF_OF_ADDRESS
-        #   - PROOF_OF_IDENTITY
-        #   - PROOF_OF_OWNERSHIP
-        #   - PROOF_OF_INCOME
-        #   - PROOF_OF_EDUCATION
-        #   - PROOF_OF_COMPLIANCE
-        #   - PROOF_OF_INSURANCE
+        $ref: "./Descriptor.yaml"
       document_examples:
         type: string
   xinput:

--- a/schema/VC.yaml
+++ b/schema/VC.yaml
@@ -45,7 +45,7 @@ properties:
     format: date-time
     description: "The expiration date of the credential, if applicable."
   credentialSubject: #things about which claims are made. Example subjects include human beings, animals, and things.
-    type: array #Expressing information related to multiple subjects in a verifiable credential is possible, for example, 2 subjcts who ar spouses and, the credential is a relationship credential.
+    type: array #Expressing information related to multiple subjects in a verifiable credential is possible, for example, 2 subjcts who are spouses and, the credential is a relationship credential.
     items:
       properties:
         id:
@@ -82,7 +82,11 @@ properties:
     type: array
     items:
       $ref: "./TagGroup.yaml"
-  status:
+  credentialStatus:
     type: array
     items:
       $ref: "./Descriptor.yaml"
+  evidence: # The evidence property is used to express supporting information, such as documentary evidence, related to the verifiable credential.
+    type: array
+    items:
+      $ref: "./TagGroup.yaml"


### PR DESCRIPTION
In some of the use cases in the verifiableCredential, an evidence field is used. 

Evidence can be included by an [issuer](https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers) to provide the [verifier](https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier) with additional supporting information in a [verifiable credential](https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential). This could be used by the [verifier](https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier) to establish the confidence with which it relies on the claims in the [verifiable credential](https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential). For example, an [issuer](https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers) could check physical documentation provided by the [subject](https://www.w3.org/TR/vc-data-model-2.0/#dfn-subjects) or perform a set of background checks before issuing the [credential](https://www.w3.org/TR/vc-data-model-2.0/#dfn-credential). In certain scenarios, this information is useful to the [verifier](https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier) when determining the risk associated with relying on a given [credential](https://www.w3.org/TR/vc-data-model-2.0/#dfn-credential).

To cover these cases, we are adding an evidence field in the credential schema.