### PR TITLE
updating the VC object schema

### DIFF
--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -2320,11 +2320,15 @@ components:
       description: Describes a Verifiable Credential
       type: object
       properties:
+        context:
+          type: array
+          items:
+            type: string
         id:
           description: 'A unique identifier for the credential (e.g., UUID or URI).'
           type: string
         type:
-          description: 'Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.'
+          description: Types of the credential.
           type: array
           items:
             type: string
@@ -2373,10 +2377,14 @@ components:
                 $ref: '#/components/schemas/Descriptor'
               tags:
                 $ref: '#/components/schemas/TagGroup'
-        claims:
+        credentialSchema:
           type: array
           items:
-            $ref: '#/components/schemas/TagGroup'
+            properties:
+              id:
+                type: string
+              type:
+                type: string
         proof:
           type: object
           description: Cryptographic proof of the credential's authenticity

--- a/schema/VC.yaml
+++ b/schema/VC.yaml
@@ -1,11 +1,15 @@
 description: Describes a Verifiable Credential
 type: object
 properties:
+  context:
+    type: array
+    items:
+      type: string
   id:
     description: A unique identifier for the credential (e.g., UUID or URI).
     type: string
   type:
-    description: Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.
+    description: Types of the credential.
     type: array
     items:
       type: string
@@ -54,10 +58,14 @@ properties:
           $ref: "./Descriptor.yaml"
         tags:
           $ref: "./TagGroup.yaml"
-  claims:
+  credentialSchema:
     type: array
     items:
-      $ref: "./TagGroup.yaml"
+      properties:
+        id:
+          type: string
+        type:
+          type: string
   proof:
     type: object
     description: "Cryptographic proof of the credential's authenticity"


### PR DESCRIPTION
1. Added the context field in the VC schema.
Motivation: [Verifiable credentials](https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential) and [verifiable presentations](https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation) MUST include a @context [property](https://www.w3.org/TR/vc-data-model-2.0/#dfn-property). Application developers MUST understand every JSON-LD context used by their application, at least to the extent that it affects the meaning of the terms used by their application.

2. Added credentialSchema field the VC schema:
Motivation: The credentialSchema [property](https://www.w3.org/TR/vc-data-model-2.0/#dfn-property) makes it possible to perform syntactic checking on the [credential](https://www.w3.org/TR/vc-data-model-2.0/#dfn-credential) and to use [verification](https://www.w3.org/TR/vc-data-model-2.0/#dfn-verify) mechanisms such as JSON Schema