### PR TITLE
reintroducing the id and type fields in the credential object 

### DIFF
--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1074,6 +1074,10 @@ components:
       description: 'Describes a credential of an entity - Person, Organization, Item, Payment etc'
       type: object
       properties:
+        id:
+          type: string
+        type:
+          type: string
         description:
           $ref: '#/components/schemas/Descriptor'
         docs:

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -1,6 +1,10 @@
 description: Describes a credential of an entity - Person, Organization, Item, Payment etc
 type: object
 properties:
+  id:
+    type: string
+  type:
+    type: string
   description:
     $ref: "./Descriptor.yaml"
   docs:


### PR DESCRIPTION
1. There already was a [Credential schema](https://github.com/beckn/protocol-specifications/blob/master/schema/Credential.yaml) in the Protocol Specification, it is referenced in the [Person](https://github.com/beckn/protocol-specifications/blob/master/schema/Person.yaml#L27) object.
2. Some [example JSONs in DHP](https://github.com/beckn/DHP-Specs/blob/draft/examples/consultation/search/on_search.json#L70) use case are using fulfillment.agent.person.creds to show the Doctor credentials.
3. As part of the hyperbeckn changes id and type fields from the credential object were removed. 
4. Adding the id and type fields in the credential object to make it backward compatible.