### PR TITLE
Adding trust in transactions using credentials

### DIFF
--- a/api/registry/README.md
+++ b/api/registry/README.md
@@ -41,7 +41,7 @@ openapi: 3.0.0
 info:
   title: Beckn Protocol Core
   description: Beckn Core API specification
-  version: "1.0.0"
+  version: "1.2.0"
 
 security:
   - SubscriberAuth: []

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1093,7 +1093,7 @@ components:
           description: URL of the credential
           type: string
           format: uri
-        vc:
+        verifiableCredential:
           $ref: '#/components/schemas/VC'
     CredentialRequest:
       description: Describes the schema used to request for a proof from an entity

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1099,13 +1099,11 @@ components:
       description: Describes the schema used to request for a proof from an entity
       type: object
       properties:
-        description:
-          $ref: '#/components/schemas/Descriptor'
         credential_purpose:
           type: object
           properties:
             purpose:
-              type: string
+              $ref: '#/components/schemas/Descriptor'
             document_examples:
               type: string
         xinput:
@@ -2406,10 +2404,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TagGroup'
-        status:
+        credentialStatus:
           type: array
           items:
             $ref: '#/components/schemas/Descriptor'
+        evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
     Vehicle:
       description: 'Describes a vehicle is a device that is designed or used to transport people or cargo over land, water, air, or through space.<br>This has properties like category, capacity, make, model, size,variant,color,energy_type,registration'
       type: object

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1060,6 +1060,9 @@ components:
           type: string
         ttl:
           $ref: '#/components/schemas/Duration'
+        verified:
+          description: 'Indicates whether the entity is verified. A value of true means the entity has successfully completed the verification process, while false indicates that the entity is either unverified or has failed verification.'
+          type: boolean
     Country:
       description: Describes a country
       type: object

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -366,6 +366,41 @@ paths:
       responses:
         default:
           $ref: '#/paths/~1init/post/responses/default'
+  /cred:
+    post:
+      tags:
+        - Beckn Provider Platform (BPP)
+      description: Request for credentials
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                context:
+                  allOf:
+                    - $ref: '#/components/schemas/Context'
+                    - properties:
+                        action:
+                          enum:
+                            - cred
+                      required:
+                        - action
+                message:
+                  type: object
+                  properties:
+                    creds:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/Credential'
+                  required:
+                    - creds
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: '#/paths/~1init/post/responses/default'
   /on_search:
     post:
       tags:
@@ -704,6 +739,42 @@ paths:
       responses:
         default:
           $ref: '#/paths/~1init/post/responses/default'
+  /on_cred:
+    post:
+      tags:
+        - Beckn Application Platform (BAP)
+      description: Callback for a credential request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                context:
+                  allOf:
+                    - $ref: '#/components/schemas/Context'
+                    - properties:
+                        action:
+                          enum:
+                            - on_cred
+                      required:
+                        - action
+                message:
+                  type: object
+                  properties:
+                    creds:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/Credential'
+                  required:
+                    - creds
+                error:
+                  $ref: '#/components/schemas/Error'
+              required:
+                - context
+      responses:
+        default:
+          $ref: '#/paths/~1init/post/responses/default'
 components:
   securitySchemes:
     SubscriberAuth:
@@ -738,10 +809,6 @@ components:
           $ref: '#/components/schemas/Descriptor'
         price:
           $ref: '#/components/schemas/Price'
-        quantity:
-          description: The Selling quantity of the Item
-          allOf:
-            - $ref: '#/components/schemas/ItemQuantity'
     Address:
       description: Describes a postal address.
       type: string
@@ -824,6 +891,7 @@ components:
           format: date-time
         cancelled_by:
           type: string
+          description: 'Indicated who canceled a specific entity, such as an order or a booking.'
           enum:
             - CONSUMER
             - PROVIDER
@@ -886,6 +954,7 @@ components:
           type: string
           format: date-time
         ttl:
+          description: Represents the validity of the request.
           $ref: '#/components/schemas/Duration'
     Category:
       description: A label under which a collection of items can be grouped.
@@ -929,8 +998,10 @@ components:
       type: object
       properties:
         phone:
+          description: Phone number of an entity.
           type: string
         email:
+          description: Email of an entity.
           type: string
         jcard:
           type: object
@@ -1000,18 +1071,43 @@ components:
           type: string
           description: Country code as per ISO 3166-1 and ISO 3166-2 format
     Credential:
-      description: Describes a credential of an entity - Person or Organization
+      description: 'Describes a credential of an entity - Person, Organization, Item, Payment etc'
       type: object
       properties:
-        id:
+        description:
+          $ref: '#/components/schemas/Descriptor'
+        credential_category:
           type: string
-        type:
-          type: string
-          default: VerifiableCredential
+          enum:
+            - AGENT
+            - CUSTOMER
+            - ORGANIZATION
+            - PAYMENT
+            - PROVIDER
+            - SUBSCRIBER
+            - FULFILLMENT
+            - ITEM
+            - ORDER
+            - PERSON
+        docs:
+          description: The Documents associated with the credential.
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        media:
+          description: The Media associated with the credential.
+          type: array
+          items:
+            $ref: '#/components/schemas/MediaFile'
         url:
           description: URL of the credential
           type: string
           format: uri
+        xinput:
+          description: A BAP can send a form which can be filled by the BAP with relevant details.
+          $ref: '#/components/schemas/XInput'
+        vc:
+          $ref: '#/components/schemas/VC'
     Customer:
       description: Describes a customer buying/availing a product or a service
       type: object
@@ -1069,13 +1165,16 @@ components:
         url:
           type: string
           format: uri
-        label:
-          type: string
         mime_type:
           description: 'Describes the contents of the uri field. If the value is text/html, it is recommended for the BAP to render the contents inside a webview. This generally does not render a good user experience on the BAP, hence the payment page developers are recommended to develop their payment pages in a mobile-friendly manner.'
           type: string
           enum:
             - application/pdf
+            - text/plain
+            - image/jpeg
+            - video/mp4
+            - audio/wav
+            - application/zip
     Domain:
       description: 'Described the industry sector or sub-sector. The network policy should contain codes for all the industry sectors supported by the network. Domains can be created in varying levels of granularity. The granularity of a domain can be decided by the participants of the network. Too broad domains will result in irrelevant search broadcast calls to BPPs that don''t have services supporting the domain. Too narrow domains will result in a large number of registry entries for each BPP. It is recommended that network facilitators actively collaborate with various working groups and network participants to carefully choose domain codes keeping in mind relevance, performance, and opportunity cost. It is recommended that networks choose broad domains like mobility, logistics, healthcare etc, and progressively granularize them as and when the number of network participants for each domain grows large.'
       type: object
@@ -1122,7 +1221,7 @@ components:
       type: object
       properties:
         url:
-          description: 'The URL from where the form can be fetched. The content fetched from the url must be processed as per the mime_type specified in this object. Once fetched, the rendering platform can choosed to render the form as-is as an embeddable element; or process it further to blend with the theme of the application. In case the interface is non-visual, the the render can process the form data and reproduce it as per the standard specified in the form.'
+          description: 'The URL from where the form can be fetched. The content fetched from the url must be processed as per the MIME type specified in this object. Once fetched, the rendering platform can choosed to render the form as-is as an embeddable element; or process it further to blend with the theme of the application. In case the interface is non-visual, the the render can process the form data and reproduce it as per the standard specified in the form.'
           type: string
           format: uri
         data:
@@ -1139,8 +1238,10 @@ components:
             - application/html
         resubmit:
           type: boolean
+          description: 'Set to true if the resubmission of a form is required. It could be due to a validation error, or session timeout etc.'
         submission_id:
           type: string
+          description: A unique identifier associated with a submission of a form.
           format: uuid
         auth:
           type: object
@@ -1149,6 +1250,7 @@ components:
               $ref: '#/components/schemas/Descriptor'
             value:
               type: string
+              description: 'The token that will be used for the authentication. It could be JWT (JSON Web Token), OAuth etc.'
     Fulfillment:
       description: Describes how a an order will be rendered/fulfilled to the end-customer
       type: object
@@ -1171,7 +1273,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/FulfillmentState'
         documents:
-          description: The Documents associated to the fullfilment
+          description: 'The Documents associated with the fullfilment object. For example in the case of online courses, it could represent a certificate of completion of a course.'
           type: array
           items:
             $ref: '#/components/schemas/Document'
@@ -1199,6 +1301,10 @@ components:
         path:
           description: The physical path taken by the agent that can be rendered on a map. The allowed format of this property can be set by the network.
           type: string
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
         tags:
           type: array
           items:
@@ -1465,6 +1571,10 @@ components:
         recommended:
           description: Whether this item is a recommended item to a response
           type: boolean
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
         ttl:
           $ref: '#/components/schemas/Duration'
         tags:
@@ -1524,7 +1634,7 @@ components:
       description: This object contains a url to a media file.
       type: object
       properties:
-        mimetype:
+        mime_type:
           description: 'indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF''s RFC 6838'
           type: string
         url:
@@ -1672,6 +1782,10 @@ components:
           description: The date-time of updated of this order
           type: string
           format: date-time
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
         xinput:
           description: Additional input required from the customer to confirm this order
           allOf:
@@ -1700,6 +1814,10 @@ components:
             - $ref: '#/components/schemas/City'
         contact:
           $ref: '#/components/schemas/Contact'
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
     Payment:
       description: 'Describes the terms of settlement between the BAP and the BPP for a single transaction. When instantiated, this object contains <ol><li>the amount that has to be settled,</li><li>The payment destination destination details</li><li>When the settlement should happen, and</li><li>A transaction reference ID</li></ol>. During a transaction, the BPP reserves the right to decide the terms of payment. However, the BAP can send its terms to the BPP first. If the BPP does not agree to those terms, it must overwrite the terms and return them to the BAP. If overridden, the BAP must either agree to the terms sent by the BPP in order to preserve the provider''s autonomy, or abort the transaction. In case of such disagreements, the BAP and the BPP can perform offline negotiations on the payment terms. Once an agreement is reached, the BAP and BPP can resume transactions.'
       type: object
@@ -1757,6 +1875,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TagGroup'
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
     Person:
       description: Describes a person as any individual
       type: object
@@ -1818,20 +1940,31 @@ components:
       properties:
         currency:
           type: string
+          description: 'Medium of exchange, traditional unit of payment, i.e. INR, USD etc.'
         value:
           type: string
+          description: 'Monetary cost of an item, a decimal represented as string'
         estimated_value:
           type: string
+          description: 'Monetary cost of an item, a decimal represented as string'
         computed_value:
           type: string
+          description: 'Monetary cost of an item, a decimal represented as string'
         listed_value:
           type: string
+          description: 'Monetary cost of an item, a decimal represented as string'
         offered_value:
           type: string
+          description: 'Monetary cost of an item, a decimal represented as string'
         minimum_value:
           type: string
+          description: 'Monetary cost of an item, a decimal represented as string'
         maximum_value:
           type: string
+          description: 'Monetary cost of an item, a decimal represented as string'
+        unit:
+          type: string
+          description: 'A unit of payment that can act as an instrument of exchange, i.e. carbon credit, bitcoin, etc.'
     Provider:
       description: Describes the catalog of a business.
       type: object
@@ -1881,6 +2014,10 @@ components:
           type: boolean
         ttl:
           $ref: '#/components/schemas/Duration'
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
         tags:
           type: array
           items:
@@ -2181,6 +2318,95 @@ components:
           enum:
             - active
             - inactive
+    VC:
+      description: Describes a Verifiable Credential
+      type: object
+      properties:
+        id:
+          description: 'A unique identifier for the credential (e.g., UUID or URI).'
+          type: string
+        type:
+          description: 'Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.'
+          type: array
+          items:
+            type: string
+        description:
+          $ref: '#/components/schemas/Descriptor'
+        issuer:
+          type: object
+          description: Entity that issued the credential
+          properties:
+            description:
+              $ref: '#/components/schemas/Descriptor'
+            address:
+              $ref: '#/components/schemas/Address'
+            state:
+              $ref: '#/components/schemas/State'
+            city:
+              $ref: '#/components/schemas/City'
+            contact:
+              $ref: '#/components/schemas/Contact'
+            registration_number:
+              type: string
+              description: 'The registration number of the organization, if applicable.'
+            website:
+              type: string
+              format: uri
+              description: The official website of the issuing organization.
+        issueDate:
+          type: string
+          format: date-time
+          description: The date when the credential was issued.
+        validFrom:
+          type: string
+          format: date-time
+          description: 'The expiration date of the credential, if applicable.'
+        validUntil:
+          type: string
+          format: date-time
+          description: 'The expiration date of the credential, if applicable.'
+        credentialSubject:
+          type: array
+          items:
+            properties:
+              id:
+                type: string
+              description:
+                $ref: '#/components/schemas/Descriptor'
+              tags:
+                $ref: '#/components/schemas/TagGroup'
+        claims:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
+        proof:
+          type: object
+          description: Cryptographic proof of the credential's authenticity
+          properties:
+            created:
+              type: string
+              format: date-time
+              description: Timestamp of when the proof was generated
+            proofPurpose:
+              type: string
+              description: 'This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity.'
+            type:
+              type: string
+              description: 'This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof.'
+            verificationMethod:
+              type: string
+              description: This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof.
+            proofValue:
+              type: string
+              description: This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity.
+        termsOfUse:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
+        status:
+          type: array
+          items:
+            $ref: '#/components/schemas/Descriptor'
     Vehicle:
       description: 'Describes a vehicle is a device that is designed or used to transport people or cargo over land, water, air, or through space.<br>This has properties like category, capacity, make, model, size,variant,color,energy_type,registration'
       type: object

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -389,12 +389,12 @@ paths:
                 message:
                   type: object
                   properties:
-                    creds:
+                    proofs:
                       type: array
                       items:
-                        $ref: '#/components/schemas/Credential'
+                        $ref: '#/components/schemas/CredentialRequest'
                   required:
-                    - creds
+                    - proofs
               required:
                 - context
                 - message
@@ -762,12 +762,12 @@ paths:
                 message:
                   type: object
                   properties:
-                    creds:
+                    proofs:
                       type: array
                       items:
                         $ref: '#/components/schemas/Credential'
                   required:
-                    - creds
+                    - proofs
                 error:
                   $ref: '#/components/schemas/Error'
               required:
@@ -1079,19 +1079,6 @@ components:
       properties:
         description:
           $ref: '#/components/schemas/Descriptor'
-        credential_category:
-          type: string
-          enum:
-            - AGENT
-            - CUSTOMER
-            - ORGANIZATION
-            - PAYMENT
-            - PROVIDER
-            - SUBSCRIBER
-            - FULFILLMENT
-            - ITEM
-            - ORDER
-            - PERSON
         docs:
           description: The Documents associated with the credential.
           type: array
@@ -1106,11 +1093,24 @@ components:
           description: URL of the credential
           type: string
           format: uri
-        xinput:
-          description: A BAP can send a form which can be filled by the BAP with relevant details.
-          $ref: '#/components/schemas/XInput'
         vc:
           $ref: '#/components/schemas/VC'
+    CredentialRequest:
+      description: Describes the schema used to request for a proof from an entity
+      type: object
+      properties:
+        description:
+          $ref: '#/components/schemas/Descriptor'
+        credential_purpose:
+          type: object
+          properties:
+            purpose:
+              type: string
+            document_examples:
+              type: string
+        xinput:
+          description: A requester can send a form which can be filled by the sender with relevant details.
+          $ref: '#/components/schemas/XInput'
     Customer:
       description: Describes a customer buying/availing a product or a service
       type: object

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1077,6 +1077,10 @@ components:
       description: 'Describes a credential of an entity - Person, Organization, Item, Payment etc'
       type: object
       properties:
+        id:
+          type: string
+        type:
+          type: string
         description:
           $ref: '#/components/schemas/Descriptor'
         docs:

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -2323,11 +2323,15 @@ components:
       description: Describes a Verifiable Credential
       type: object
       properties:
+        context:
+          type: array
+          items:
+            type: string
         id:
           description: 'A unique identifier for the credential (e.g., UUID or URI).'
           type: string
         type:
-          description: 'Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.'
+          description: Types of the credential.
           type: array
           items:
             type: string
@@ -2376,10 +2380,14 @@ components:
                 $ref: '#/components/schemas/Descriptor'
               tags:
                 $ref: '#/components/schemas/TagGroup'
-        claims:
+        credentialSchema:
           type: array
           items:
-            $ref: '#/components/schemas/TagGroup'
+            properties:
+              id:
+                type: string
+              type:
+                type: string
         proof:
           type: object
           description: Cryptographic proof of the credential's authenticity

--- a/api/transaction/components/index.yaml
+++ b/api/transaction/components/index.yaml
@@ -147,7 +147,19 @@ paths:
       responses:
         default:
           $ref: "./io/Response.yaml"
-
+  /cred:
+    post:
+      tags:
+        - Beckn Provider Platform (BPP)
+      description: Request for credentials
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref : "./io/Cred.yaml"
+      responses:
+        default:
+          $ref: "./io/Response.yaml"
   /on_search:
     post:
       tags:
@@ -283,6 +295,19 @@ paths:
           application/json:
             schema:
               $ref: "./io/OnSupport.yaml"
+      responses:
+        default:
+          $ref: "./io/Response.yaml"
+  /on_cred:
+    post:
+      tags:
+        - Beckn Application Platform (BAP)
+      description: Callback for a credential request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "./io/OnCred.yaml"
       responses:
         default:
           $ref: "./io/Response.yaml"

--- a/api/transaction/components/io/Cred.yaml
+++ b/api/transaction/components/io/Cred.yaml
@@ -1,0 +1,23 @@
+type: object
+properties:
+  context:
+    allOf:
+      - $ref: "../../../../schema/Context.yaml"
+      - properties:
+          action:
+            enum:
+              - cred
+        required:
+          - action
+  message:
+    type: object
+    properties:
+      creds:
+        type: array
+        items:
+          $ref: "../../../../schema/Credential.yaml"
+    required:
+      - creds
+required:
+  - context
+  - message

--- a/api/transaction/components/io/Cred.yaml
+++ b/api/transaction/components/io/Cred.yaml
@@ -12,12 +12,12 @@ properties:
   message:
     type: object
     properties:
-      creds:
+      proofs:
         type: array
         items:
-          $ref: "../../../../schema/Credential.yaml"
+          $ref: "../../../../schema/CredentialRequest.yaml"
     required:
-      - creds
+      - proofs
 required:
   - context
   - message

--- a/api/transaction/components/io/OnCred.yaml
+++ b/api/transaction/components/io/OnCred.yaml
@@ -12,12 +12,12 @@ properties:
   message:
     type: object
     properties:
-      creds:
+      proofs:
         type: array
         items:
           $ref: "../../../../schema/Credential.yaml"
     required:
-      - creds
+      - proofs
   error:
     $ref: "../../../../schema/Error.yaml"
 required:

--- a/api/transaction/components/io/OnCred.yaml
+++ b/api/transaction/components/io/OnCred.yaml
@@ -1,0 +1,24 @@
+type: object
+properties:
+  context:
+    allOf:
+      - $ref: "../../../../schema/Context.yaml"
+      - properties:
+          action:
+            enum:
+              - on_cred
+        required:
+          - action
+  message:
+    type: object
+    properties:
+      creds:
+        type: array
+        items:
+          $ref: "../../../../schema/Credential.yaml"
+    required:
+      - creds
+  error:
+    $ref: "../../../../schema/Error.yaml"
+required:
+  - context

--- a/api/transaction/components/schema/index.yaml
+++ b/api/transaction/components/schema/index.yaml
@@ -46,6 +46,9 @@ Country:
 Credential:
   $ref: "../../../../schema/Credential.yaml"
 
+CredentialRequest:
+  $ref: "../../../../schema/CredentialRequest.yaml"
+
 Customer:
   $ref: "../../../../schema/Customer.yaml"
 

--- a/api/transaction/components/schema/index.yaml
+++ b/api/transaction/components/schema/index.yaml
@@ -166,6 +166,9 @@ Time:
 Tracking:
   $ref: "../../../../schema/Tracking.yaml"
 
+VC:
+  $ref: "../../../../schema/VC.yaml"
+
 Vehicle:
   $ref: "../../../../schema/Vehicle.yaml"
 

--- a/docs/BECKN-001-Layering-Network-Policy.md
+++ b/docs/BECKN-001-Layering-Network-Policy.md
@@ -1,5 +1,10 @@
 # BECKN-001:Layering Network Policy on the Specification
 
+## License:
+This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+
+![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
+
 ## Category:
 Network Policy
 December 10, 2021
@@ -7,20 +12,22 @@ December 10, 2021
 ## Last Updated on:
 July 2nd, 2024 
 
-## License:
-This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+## History: 
+Click on this [link](https://github.com/beckn/protocol-specifications/commits/core-1.2-release/docs/BECKN-001-Layering-Network-Policy.md) to view the history of changes to this document
 
-![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
+## Issues:
+To view issues related to this document, click on this [link](https://github.com/beckn/protocol-specifications/issues?q=is%3Aissue+label%3ABECKN-001)
+
+## Discussions:
+To view discussions related to this document, click on this [link](https://github.com/beckn/protocol-specifications/discussions?discussions_q=label%3ABECKN-001)
 
 ## Authors:
-1. Ravi Prakash : ravi@becknprotocol.io
+1. [Ravi Prakash](https://github.com/ravi-prakash-v)
 
 ## Reviewers:
-1. Sujith Nair : sujith@becknprotocol.io
-2. Pramod Varma : pramod@ekstep.org
-3. Venkatraman Mahadevan : venkatramanm@gmail.com
-
-replace email with github ids.
+1. [Sujith Nair](https://github.com/sjthnrk)
+2. [Pramod Varma](https://github.com/pramodkvarma)
+3. [Venkatraman Mahadevan](https://github.com/venkatramanm)
 
 # Scope
 This document contains design principles and methodologies that should be used to configure beckn protocol specification for various sector-specific networks. This document is intended for the following audience.

--- a/docs/BECKN-002-Payments-On-Beckn-Enabled-Networks.md
+++ b/docs/BECKN-002-Payments-On-Beckn-Enabled-Networks.md
@@ -1,36 +1,35 @@
-# Payments on Beckn-Enabled Networks
+# BECKN-002:Payments on Beckn-Enabled Networks
 
+## License:
+This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
-## ID: 
-BECKN-RFC-002
-
-## Draft ID
-Draft-01
-
-## Title:
-Payments on Beckn-Enabled Networks
+![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
 
 ## Category:
-Payments
-
-## Status:
-Protocol Draft
+Payment
 
 ## Published on:
 December 10, 2021
 
-## Expires on:
-April 05, 2022 or Date of publication of next draft which ever is earlier
+## Last Updated on:
+July 4th, 2024
 
-## License:
-CC-BY-ND
+## History: 
+Click on this [link](https://github.com/beckn/protocol-specifications/commits/core-1.2-release/docs/BECKN-002-Payments-On-Beckn-Enabled-Networks.md) to view the history of changes to this document
+
+## Issues:
+To view issues related to this document, click on this [link](https://github.com/beckn/protocol-specifications/issues?q=is%3Aissue+label%3ABECKN-002)
+
+## Discussions:
+To view discussions related to this document, click on this [link](https://github.com/beckn/protocol-specifications/discussions?discussions_q=label%3ABECKN-002)
 
 ## Authors:
-1. Ravi Prakash : ravi@becknfoundation.org
+1. [Ravi Prakash](https://github.com/ravi-prakash-v)
 
 ## Reviewers:
-1. Sujith Nair : sujith@becknfoundation.org
-2. Pramod Varma : pramod@ekstep.org
+1. [Sujith Nair](https://github.com/sjthnrk)
+2. [Pramod Varma](https://github.com/pramodkvarma)
+3. [Venkatraman Mahadevan](https://github.com/venkatramanm)
 
 # Introduction
 In beckn-enabled networks, payments are expected to be settled outside the network. Meaning, the implementers of beckn-enabled applications are expected to use existing payment infrastructures in their region(s) of operation to collect, process and settle payments. Since payments is a highly regulated industry across the world, different geo-political regions may choose different standards and modalities to enable digital payments.  Therefore, it is left to the implementer to templatize such region-specific payment modalities and dynamically enable them on the respective user applications of both the payer and payee, based on their respective geo-political locations. 

--- a/docs/BECKN-003-Beckn-Protocol-Communication.md
+++ b/docs/BECKN-003-Beckn-Protocol-Communication.md
@@ -1,38 +1,40 @@
-# Beckn Protocol Communication
+# BECKN-003:Beckn Protocol Communication
 
-## ID 
-BECKN-RFC-003
+## License:
+This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
-## Draft ID
-Draft-01
-
-## Title
-Beckn Protocol Communication
+![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
 
 ## Category
 Communication
 
-## Status
-Protocol Draft
-
 ## Published on
 December 10, 2021
 
-## Expires on
-December 10, 2021 or Date of publication of next draft which ever is earlier
+## Last Updated on:
+July 4th, 2024
 
-## License
-CC-BY-ND
+## History: 
+Click on this [link](https://github.com/beckn/protocol-specifications/commits/core-1.2-release/docs/BECKN-003-Beckn-Protocol-Communication.md) to view the history of changes to this document
 
-## Authors
-1. Ravi Prakash : ravi@becknfoundation.org
+## Issues:
+To view issues related to this document, click on this [link](https://github.com/beckn/protocol-specifications/issues?q=is%3Aissue+label%3ABECKN-003)
 
-## Reviewers
-1. Sujith Nair : sujith@becknfoundation.org
-2. Pramod Varma : pramod@ekstep.org
+## Discussions:
+To view discussions related to this document, click on this [link](https://github.com/beckn/protocol-specifications/discussions?discussions_q=label%3ABECKN-003)
+
+## Authors:
+1. [Ravi Prakash](https://github.com/ravi-prakash-v)
+
+## Reviewers:
+1. [Sujith Nair](https://github.com/sjthnrk)
+2. [Pramod Varma](https://github.com/pramodkvarma)
+3. [Venkatraman Mahadevan](https://github.com/venkatramanm)
 
 # Abstract
-Communication on beckn enabled networks is server-to-server. Server-to-server means that communication between any two systems on a beckn network does not involve the client application. The client is free to render the data in whatever form chosen by the product. Secondly, all communication is asynchronous. Asynchronous API calls do not block (or wait) for the API call to return from the receiver server in the same session. Instead, an immediate acknowledgment is sent to the sender server in the same session and the actual response from the receiver server is in the form of a callback API call to the sender server. The above two features provide a remarkable advantage as all sorts of innovations are possible in the application layer due to the experience layer being unbundled from the session and presentation layer of the application.
+Communication on beckn enabled networks is server-to-server. Server-to-server means that communication between any two systems on a beckn network does not involve the client application (like the website or the mobile app). The client is thus free to render the data in whatever form chosen by the product. 
+
+Secondly, all communication is asynchronous. Asynchronous API calls do not block (or wait) for the response to return from the receiver server in the same session. This is done to replicate real-world behaviour of economic transactions across various domains and use cases. For example, a hotel booking confirmation request does not _always_ get a response in the same session. Sometimes the customer needs to wait for 24 hours or more to receive a confirmation. Sometimes the provider needs to send information to the consumer without them explicitly requesting it like in the case of a driver cancelling a confirmed ride before pickup. Such asynchronocity avoids the BAP continously polling the BPP until it receives a status update. Instead, an immediate acknowledgment is sent to the BAP in the same session and the actual response from the BPP is in the form of a callback API call to the BAP. The above two features provide a remarkable advantage as all sorts of innovations are possible in the application layer due to the experience layer being unbundled from the session and presentation layer of the application.
 
 # Introduction
 A beckn enabled network has multiple entities communicating with each other via standard protocol APIs. The following types of communication are possible.

--- a/docs/BECKN-004-Policy-Administration-On-Beckn-Enabled-Networks.md
+++ b/docs/BECKN-004-Policy-Administration-On-Beckn-Enabled-Networks.md
@@ -1,37 +1,35 @@
-# Policy Administration on Beckn-Enabled Networks
+# BECKN-004:Policy Administration on Beckn-Enabled Networks
 
-## ID: 
-BECKN-RFC-004
+## License:
+This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
-## Draft ID
-Draft-01
-
-## Title:
-Policy Administration on Beckn-Enabled Networks
+![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
 
 ## Category:
 Policy
 
-## Status:
-Protocol Draft
-
 ## Published on:
 December 10, 2021
 
-## Expires on:
-December 10, 2022 or Date of publication of next draft which ever is earlier
+## Last Updated on:
+July 4th, 2024
 
-## License:
-CC-BY-ND
+## History: 
+Click on this [link](https://github.com/beckn/protocol-specifications/commits/core-1.2-release/docs/BECKN-004-Policy-Administration-On-Beckn-Enabled-Networks.md) to view the history of changes to this document
+
+## Issues:
+To view issues related to this document, click on this [link](https://github.com/beckn/protocol-specifications/issues?q=is%3Aissue+label%3ABECKN-004)
+
+## Discussions:
+To view discussions related to this document, click on this [link](https://github.com/beckn/protocol-specifications/discussions?discussions_q=label%3ABECKN-004)
 
 ## Authors:
-1. Ravi Prakash : ravi@becknfoundation.org
-2. Sujith Nair : sujith@becknfoundation.org
+1. [Ravi Prakash](https://github.com/ravi-prakash-v)
 
 ## Reviewers:
-1. Sujith Nair : sujith@becknfoundation.org
-2. Pramod Varma : pramod@ekstep.org
-
+1. [Sujith Nair](https://github.com/sjthnrk)
+2. [Pramod Varma](https://github.com/pramodkvarma)
+3. [Venkatraman Mahadevan](https://github.com/venkatramanm)
 
 # Introduction
 

--- a/docs/BECKN-005-Error-Codes.md
+++ b/docs/BECKN-005-Error-Codes.md
@@ -1,28 +1,35 @@
-# Error Codes for BPP
+# BECKN-005:Error Codes for BPP
 
-## ID: 
-BECKN-005
+## License:
+This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
-## Draft ID
-Draft-01
+![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
 
-## Title:
+## Category:
 Error Codes
-
-## Status:
-Protocol Draft
 
 ## Published on:
 January 21, 2022
 
-## Expires on:
-January 20, 2023 or Date of publication of next draft which ever is earlier
+## Last Updated on:
+July 4th, 2024
 
-## License:
-CC-BY-ND
+## History: 
+Click on this [link](https://github.com/beckn/protocol-specifications/commits/core-1.2-release/docs/BECKN-005-Error-Codes.md) to view the history of changes to this document
+
+## Issues:
+To view issues related to this document, click on this [link](https://github.com/beckn/protocol-specifications/issues?q=is%3Aissue+label%3ABECKN-005)
+
+## Discussions:
+To view discussions related to this document, click on this [link](https://github.com/beckn/protocol-specifications/discussions?discussions_q=label%3ABECKN-005)
 
 ## Authors:
-1. Ravi Prakash : ravi@becknfoundation.org
+1. [Ravi Prakash](https://github.com/ravi-prakash-v)
+
+## Reviewers:
+1. [Sujith Nair](https://github.com/sjthnrk)
+2. [Pramod Varma](https://github.com/pramodkvarma)
+3. [Venkatraman Mahadevan](https://github.com/venkatramanm)
 
 ## Introduction
   This document outlines the error codes which must be returned by a BPP. 
@@ -60,7 +67,7 @@ CC-BY-ND
   |50004|Support unavailable|When the BPP receives an object if for which it does not provide support|
 
   ## Acknowledgements
-  The author would like to thank the following individuals for their contributions in creating the first draft of this document (in alphabetical order):
+  The author would like to thank the following individuals for their contributions in creating this document (in alphabetical order):
 
 1. Pramod Varma, Beckn Foundation
 2. Sujith Nair, Beckn Foundation

--- a/docs/BECKN-006-Signing-Beckn-APIs-In-HTTP.md
+++ b/docs/BECKN-006-Signing-Beckn-APIs-In-HTTP.md
@@ -1,4 +1,35 @@
-# Signing Beckn APIs in HTTP - Draft 04
+# BECKN-006:Signing Beckn APIs in HTTP
+
+## License:
+This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+
+![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
+
+## Category:
+Authentication
+
+## Published on:
+January 21, 2022
+
+## Last Updated on:
+July 4th, 2024
+
+## History: 
+Click on this [link](https://github.com/beckn/protocol-specifications/commits/core-1.2-release/docs/BECKN-006-Signing-Beckn-APIs-In-HTTP.md) to view the history of changes to this document
+
+## Issues:
+To view issues related to this document, click on this [link](https://github.com/beckn/protocol-specifications/issues?q=is%3Aissue+label%3ABECKN-006)
+
+## Discussions:
+To view discussions related to this document, click on this [link](https://github.com/beckn/protocol-specifications/discussions?discussions_q=label%3ABECKN-006)
+
+## Authors:
+1. [Ravi Prakash](https://github.com/ravi-prakash-v)
+
+## Reviewers:
+1. [Sujith Nair](https://github.com/sjthnrk)
+2. [Pramod Varma](https://github.com/pramodkvarma)
+3. [Venkatraman Mahadevan](https://github.com/venkatramanm)
 
 ## Context
 When communicating over HTTP using Beckn APIs, the subscribers need to authenticate themselves to perform transactions with other subscribers. Due to the commercial nature of the transactions, every request/callback pair is considered to be a "contract" between two parties. Therefore, it is imperative that all requests and callbacks are digitally signed by the sender and subsequently verified by the receiver.

--- a/docs/BECKN-007-The-XInput-Schema.md
+++ b/docs/BECKN-007-The-XInput-Schema.md
@@ -1,36 +1,35 @@
-# The XInput Schema
-#### CWG Working Draft - November 08, 2022
+# BECKN-007:The XInput Schema
 
-## Document Details
-### This version
-https://github.com/beckn/protocol-specifications/blob/release-1.x/docs/BECKN-007-The-XInput-Schema.md
+## License:
+This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
-### Latest published version
-TODO
+![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
 
-### Latest editor's draft
-TODO
+## Category:
+XInput
 
-### Implementation report
-TODO
+## Published on:
+January 21, 2022
 
-### Editors
-Ravi Prakash (Beckn Foundation)
+## Last Updated on:
+July 4th, 2024
 
-### Authors
-Ravi Prakash (Beckn Foundation)
+## History: 
+Click on this [link](https://github.com/beckn/protocol-specifications/commits/core-1.2-release/docs/BECKN-007-The-XInput-Schema.md) to view the history of changes to this document
 
+## Issues:
+To view issues related to this document, click on this [link](https://github.com/beckn/protocol-specifications/issues?q=is%3Aissue+label%3ABECKN-007)
 
-### Feedback
+## Discussions:
+To view discussions related to this document, click on this [link](https://github.com/beckn/protocol-specifications/discussions?discussions_q=label%3ABECKN-007)
 
-Issues: TODO
-Discussions: TODO
-PRs: TODO
+## Authors:
+1. [Ravi Prakash](https://github.com/ravi-prakash-v)
 
-
-### Errata
-No Errata exists as of now
-
+## Reviewers:
+1. [Sujith Nair](https://github.com/sjthnrk)
+2. [Pramod Varma](https://github.com/pramodkvarma)
+3. [Venkatraman Mahadevan](https://github.com/venkatramanm)
 
 ## Context
 Beckn protocol defines a domain-agnostic specification that can be used to represent any customer- provider transaction by implementing a standard set of APIs and schema. Creating a transaction ideally involves the customer discovering products and services offered by various providers, selecting the desired products or services, obtaining the terms of service and payment, and then finally confirming the order. But sometimes,  the provider might require additional metadata in order to confirm a transaction. This requirement may be due to legal requirements imposed by the regulatory authorities, or business requirements to allow better serviceability. 
@@ -109,7 +108,7 @@ It starts with a schema called `XInput` of type `Form`. The definition of `Form`
    properties:
      code:
        type: string
-       description: For full list of error codes, refer to docs/protocol-drafts/BECKN-RFC-005-ERROR-CODES-DRAFT-01.md of this repo
+       description: For full list of error codes, refer to docs/BECKN-005-Error-Codes.md of this repo
      path:
        type: string
        description: Path to json schema generating the error. Used only during json schema validation errors

--- a/docs/BECKN-008-Rating-and-Reputation-on-Beckn-Protocol.md
+++ b/docs/BECKN-008-Rating-and-Reputation-on-Beckn-Protocol.md
@@ -1,11 +1,36 @@
-# Rating and Reputation on Beckn Protocol
+# BECKN-008:Rating and Reputation on Beckn Protocol
 
-*Draft 01*
+## License:
+This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
-Author:
-=======
+![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
 
-Ravi Prakash (ravi@becknfoundation.org)
+## Category:
+Rating and Reputation
+
+## Published on:
+January 21, 2022
+
+## Last Updated on:
+July 4th, 2024
+
+## History: 
+Click on this [link](https://github.com/beckn/protocol-specifications/commits/core-1.2-release/docs/BECKN-008-Rating-and-Reputation-on-Beckn-Protocol.md) to view the history of changes to this document
+
+## Issues:
+To view issues related to this document, click on this [link](https://github.com/beckn/protocol-specifications/issues?q=is%3Aissue+label%3ABECKN-008)
+
+## Discussions:
+To view discussions related to this document, click on this [link](https://github.com/beckn/protocol-specifications/discussions?discussions_q=label%3ABECKN-008)
+
+## Authors:
+1. [Ravi Prakash](https://github.com/ravi-prakash-v)
+
+## Reviewers:
+1. [Sujith Nair](https://github.com/sjthnrk)
+2. [Pramod Varma](https://github.com/pramodkvarma)
+3. [Venkatraman Mahadevan](https://github.com/venkatramanm)
+
 
 Scope
 =====

--- a/docs/BECKN-009-Tags-the-Edge-of-Beckn.md
+++ b/docs/BECKN-009-Tags-the-Edge-of-Beckn.md
@@ -1,52 +1,35 @@
-# Document Details
-## Supported Protocol Version
+# BECKN-009:Tags, the Edge of Beckn
 
-TODO
+## License:
+This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
+![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
 
-## This version
+## Category:
+Tags
 
-TODO
+## Published on:
+January 21, 2022
 
+## Last Updated on:
+July 4th, 2024
 
-## Latest published version
+## History: 
+Click on this [link](https://github.com/beckn/protocol-specifications/commits/core-1.2-release/docs/BECKN-009-Tags-the-Edge-of-Beckn.md) to view the history of changes to this document
 
-TODO
+## Issues:
+To view issues related to this document, click on this [link](https://github.com/beckn/protocol-specifications/issues?q=is%3Aissue+label%3ABECKN-009)
 
+## Discussions:
+To view discussions related to this document, click on this [link](https://github.com/beckn/protocol-specifications/discussions?discussions_q=label%3ABECKN-009)
 
-## Latest editor's draft
+## Authors:
+1. [Ravi Prakash](https://github.com/ravi-prakash-v)
 
-TODO
-
-## Stress Test report
-
-TODO
-
-## Implementation report
-
-TODO
-
-
-## Editors
-Ravi Prakash (Beckn Foundation)
-
-
-## Authors
-Ravi Prakash (Beckn Foundation)
-
-
-## Feedback
-
-Issues: TODO
-
-Discussions : TODO
-
-PRs : TODO
-
-
-## Errata
-
-No Errata exists as of now
+## Reviewers:
+1. [Sujith Nair](https://github.com/sjthnrk)
+2. [Pramod Varma](https://github.com/pramodkvarma)
+3. [Venkatraman Mahadevan](https://github.com/venkatramanm)
 
 
 # Context
@@ -278,8 +261,6 @@ TODO
 # Acknowledgements
 
 The author would like to thank the following	people for their support and contributions to this document. 
-
-
 
 1. Venkataramanan Mahadevan
 2. Pramod Varma

--- a/docs/BECKN-010-Keyword-Definitions-for-Technical-Specifications.md
+++ b/docs/BECKN-010-Keyword-Definitions-for-Technical-Specifications.md
@@ -1,34 +1,36 @@
-# Keyword Definitions for Technical Specifications
+# BECKN-010:Keyword Definitions for Technical Specifications
 
-#### CWG Working Draft - September 01, 2023
+## License:
+This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
-## Document Details
-### This version
-https://github.com/beckn/protocol-specifications/blob/release-1.x/docs/BECKN-010-Keyword-Definitions-for-Technical-Specifications.md
+![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
 
-### Latest published version
-None
+## Category:
+Keywords for Technical Specification
 
-### Latest editor's draft
-https://github.com/beckn/protocol-specifications/blob/release-1.x/docs/BECKN-010-Keyword-Definitions-for-Technical-Specifications.md
+## Published on:
+January 21, 2022
 
-### Implementation report
-TODO
+## Last Updated on:
+July 4th, 2024
 
-### Editors
-Ravi Prakash (FIDE)
+## History: 
+Click on this [link](https://github.com/beckn/protocol-specifications/commits/core-1.2-release/docs/BECKN-010-Keyword-Definitions-for-Technical-Specifications.md) to view the history of changes to this document
 
-### Authors
-Ravi Prakash (FIDE)
+## Issues:
+To view issues related to this document, click on this [link](https://github.com/beckn/protocol-specifications/issues?q=is%3Aissue+label%3ABECKN-010)
 
-### Feedback
+## Discussions:
+To view discussions related to this document, click on this [link](https://github.com/beckn/protocol-specifications/discussions?discussions_q=label%3ABECKN-010)
 
-Issues: TODO
-Discussions: TODO
-PRs: TODO
+## Authors:
+1. [Ravi Prakash](https://github.com/ravi-prakash-v)
 
-### Errata
-No Errata exists as of now
+## Reviewers:
+1. [Sujith Nair](https://github.com/sjthnrk)
+2. [Pramod Varma](https://github.com/pramodkvarma)
+3. [Venkatraman Mahadevan](https://github.com/venkatramanm)
+
 
 ## Abstract
 

--- a/docs/BECKN-011-Search-Provider.md
+++ b/docs/BECKN-011-Search-Provider.md
@@ -1,14 +1,41 @@
-# Search Provider <!-- Metadata: type: Outline; tags: todo; created: 2023-07-29 23:48:05; reads: 291; read: 2023-08-05 18:57:52; revision: 291; modified: 2023-08-05 18:57:52; importance: 1/5; urgency: 1/5; -->
+# BECKN-011:Search Provider
 
+## License:
+This document is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
-# Context <!-- Metadata: type: Note; created: 2023-07-29 23:48:05; reads: 13; read: 2023-08-05 00:27:13; revision: 10; modified: 2023-08-05 00:27:09; -->
+![Creative Commons License](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)
+
+## Category:
+Search Provider
+
+## Published on:
+July 29th, 2023
+
+## Last Updated on:
+July 4th, 2024
+
+## History: 
+Click on this [link](https://github.com/beckn/protocol-specifications/commits/core-1.2-release/docs/BECKN-011-Search-Provider.md) to view the history of changes to this document
+
+## Issues:
+To view issues related to this document, click on this [link](https://github.com/beckn/protocol-specifications/issues?q=is%3Aissue+label%3ABECKN-011)
+
+## Discussions:
+To view discussions related to this document, click on this [link](https://github.com/beckn/protocol-specifications/discussions?discussions_q=label%3ABECKN-011)
+
+## Authors:
+1. [Ravi Prakash](https://github.com/ravi-prakash-v)
+
+## Reviewers:
+1. [Sujith Nair](https://github.com/sjthnrk)
+2. [Pramod Varma](https://github.com/pramodkvarma)
+3. [Venkatraman Mahadevan](https://github.com/venkatramanm)
+
+# Context
 When BAP fires a `/search` on the gateway, the gateway needs to `lookup` on the registry for all available BPPS that are up and running and cascade the call on to those BPPS. These BPPS in turn do the processing and respond with an `on_search` callback to the BAP. All this takes time and is fairly repetitive. To overcome this problem on the user experience, Buyer apps have arrived at several strategies like : 
 1. Cache the entire catalogue of the sellers 
 2. Pull incremental changes to catalogue from sellers based on timestamping. 
 3. Have BPPS push  their catalogue changes to all the BAPS on the network.
-
-
-
 
 
 # Problem <!-- Metadata: type: Note; created: 2023-07-29 23:48:05; reads: 13; read: 2023-08-05 18:51:59; revision: 3; modified: 2023-08-05 00:29:50; -->
@@ -76,7 +103,6 @@ Examples to be documented here.
 # Acknowledgements <!-- Metadata: type: Note; created: 2023-07-29 23:48:05; reads: 3; read: 2023-08-05 00:15:13; revision: 1; modified: 2023-07-29 23:48:05; -->
 
 The author would like to thank the following people for their support and contributions to this document. 
-
 
 1. Ravi Prakash
 2. Pramod Varma

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 # Protocol Drafts
 
-These files contain specifications that have been selected from the proposals submitted to the beckn protocol specifications. The are currently under review by different working groups in the various categories supported beckn protocol governance.
+These files contain specifications that have been selected from the proposals submitted to the beckn protocol specifications. They are currently under review by different working groups in the various categories supported by beckn protocol governance.
 
 After sufficient deliberation, these drafts may be published as a Protocol Standard.

--- a/schema/AddOn.yaml
+++ b/schema/AddOn.yaml
@@ -8,8 +8,4 @@ properties:
     $ref: "./Descriptor.yaml"
   price:
     $ref: "./Price.yaml"
-  quantity:
-    description: The Selling quantity of the Item
-    allOf:
-      - $ref: "./ItemQuantity.yaml"
 

--- a/schema/Cancellation.yaml
+++ b/schema/Cancellation.yaml
@@ -7,6 +7,7 @@ properties:
     format: date-time
   cancelled_by:
     type: string
+    description: Indicated who canceled a specific entity, such as an order or a booking.
     enum:
       - CONSUMER
       - PROVIDER

--- a/schema/Catalog.yaml
+++ b/schema/Catalog.yaml
@@ -27,4 +27,5 @@ properties:
     type: string
     format: date-time
   ttl:
+    description: Represents the validity of the request.
     $ref: "./Duration.yaml"

--- a/schema/Contact.yaml
+++ b/schema/Contact.yaml
@@ -2,8 +2,10 @@ description: Describes the contact information of an entity
 type: object
 properties:
   phone:
+    description: Phone number of an entity.
     type: string
   email:
+    description: Email of an entity.
     type: string
   jcard:
     type: object

--- a/schema/Context.yaml
+++ b/schema/Context.yaml
@@ -48,4 +48,7 @@ properties:
     type: string
   ttl:
     $ref: "./Duration.yaml"
+  verified:
+    description: Indicates whether the entity is verified. A value of true means the entity has successfully completed the verification process, while false indicates that the entity is either unverified or has failed verification.
+    type: boolean
 

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -1,6 +1,10 @@
 description: Describes a credential of an entity - Person, Organization, Item, Payment etc
 type: object
 properties:
+  id:
+    type: string
+  type:
+    type: string
   description:
     $ref: "./Descriptor.yaml"
   docs:

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -3,19 +3,6 @@ type: object
 properties:
   description:
     $ref: "./Descriptor.yaml"
-  credential_category:
-    type: string
-    enum:
-      - AGENT
-      - CUSTOMER
-      - ORGANIZATION
-      - PAYMENT
-      - PROVIDER
-      - SUBSCRIBER
-      - FULFILLMENT
-      - ITEM
-      - ORDER
-      - PERSON
   docs:
     description: The Documents associated with the credential.
     type: array
@@ -30,9 +17,6 @@ properties:
     description: URL of the credential
     type: string
     format: uri
-  xinput:
-    description: A BAP can send a form which can be filled by the BAP with relevant details.
-    $ref: "./XInput.yaml"
   vc:
     $ref: "./VC.yaml"
 

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -1,13 +1,39 @@
-description: Describes a credential of an entity - Person or Organization
+description: Describes a credential of an entity - Person, Organization, Item, Payment etc
 type: object
 properties:
-  id:
+  description:
+    $ref: "./Descriptor.yaml"
+  credential_category:
     type: string
-  type:
-    type: string
-    default: "VerifiableCredential"
+    enum:
+      - AGENT
+      - CUSTOMER
+      - ORGANIZATION
+      - PAYMENT
+      - PROVIDER
+      - SUBSCRIBER
+      - FULFILLMENT
+      - ITEM
+      - ORDER
+      - PERSON
+  docs:
+    description: The Documents associated with the credential.
+    type: array
+    items:
+      $ref: "./Document.yaml"
+  media:
+    description: The Media associated with the credential.
+    type: array
+    items:
+      $ref: "./MediaFile.yaml"
   url:
     description: URL of the credential
     type: string
     format: uri
+  xinput:
+    description: A BAP can send a form which can be filled by the BAP with relevant details.
+    $ref: "./XInput.yaml"
+  vc:
+    $ref: "./VC.yaml"
+
 

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -17,7 +17,7 @@ properties:
     description: URL of the credential
     type: string
     format: uri
-  vc:
+  verifiableCredential:
     $ref: "./VC.yaml"
 
 

--- a/schema/CredentialRequest.yaml
+++ b/schema/CredentialRequest.yaml
@@ -1,0 +1,23 @@
+description: Describes the schema used to request for a proof from an entity
+type: object
+properties:
+  description:
+    $ref: "./Descriptor.yaml"
+  credential_purpose:
+    type: object
+    properties:
+      purpose:
+        type: string
+        # enum:
+        #   - PROOF_OF_ADDRESS
+        #   - PROOF_OF_IDENTITY
+        #   - PROOF_OF_OWNERSHIP
+        #   - PROOF_OF_INCOME
+        #   - PROOF_OF_EDUCATION
+        #   - PROOF_OF_COMPLIANCE
+        #   - PROOF_OF_INSURANCE
+      document_examples:
+        type: string
+  xinput:
+    description: A requester can send a form which can be filled by the sender with relevant details.
+    $ref: "./XInput.yaml"

--- a/schema/CredentialRequest.yaml
+++ b/schema/CredentialRequest.yaml
@@ -1,21 +1,11 @@
 description: Describes the schema used to request for a proof from an entity
 type: object
-properties:
-  description:
-    $ref: "./Descriptor.yaml"
+properties:    
   credential_purpose:
     type: object
     properties:
       purpose:
-        type: string
-        # enum:
-        #   - PROOF_OF_ADDRESS
-        #   - PROOF_OF_IDENTITY
-        #   - PROOF_OF_OWNERSHIP
-        #   - PROOF_OF_INCOME
-        #   - PROOF_OF_EDUCATION
-        #   - PROOF_OF_COMPLIANCE
-        #   - PROOF_OF_INSURANCE
+        $ref: "./Descriptor.yaml"
       document_examples:
         type: string
   xinput:

--- a/schema/Document.yaml
+++ b/schema/Document.yaml
@@ -7,10 +7,13 @@ properties:
   url:
     type: string
     format: uri
-  label:
-    type: string
   mime_type:
     description: Describes the contents of the uri field. If the value is text/html, it is recommended for the BAP to render the contents inside a webview. This generally does not render a good user experience on the BAP, hence the payment page developers are recommended to develop their payment pages in a mobile-friendly manner.
     type: string
     enum:
       - application/pdf
+      - text/plain
+      - image/jpeg
+      - video/mp4
+      - audio/wav
+      - application/zip

--- a/schema/Form.yaml
+++ b/schema/Form.yaml
@@ -2,7 +2,7 @@ description: Describes a form
 type: object
 properties:
   url:
-    description: The URL from where the form can be fetched. The content fetched from the url must be processed as per the mime_type specified in this object. Once fetched, the rendering platform can choosed to render the form as-is as an embeddable element; or process it further to blend with the theme of the application. In case the interface is non-visual, the the render can process the form data and reproduce it as per the standard specified in the form.
+    description: The URL from where the form can be fetched. The content fetched from the url must be processed as per the MIME type specified in this object. Once fetched, the rendering platform can choosed to render the form as-is as an embeddable element; or process it further to blend with the theme of the application. In case the interface is non-visual, the the render can process the form data and reproduce it as per the standard specified in the form.
     type: string
     format: uri
   data:
@@ -19,8 +19,10 @@ properties:
       - application/html
   resubmit: 
     type: boolean
+    description: Set to true if the resubmission of a form is required. It could be due to a validation error, or session timeout etc.
   submission_id:
     type: string
+    description: A unique identifier associated with a submission of a form.
     format: uuid
   auth: 
     type: object
@@ -29,3 +31,4 @@ properties:
         $ref: "./Descriptor.yaml"
       value: 
         type: string
+        description: The token that will be used for the authentication. It could be JWT (JSON Web Token), OAuth etc.

--- a/schema/Fulfillment.yaml
+++ b/schema/Fulfillment.yaml
@@ -19,7 +19,7 @@ properties:
     allOf: 
       - $ref: "./FulfillmentState.yaml"
   documents:
-    description: The Documents associated to the fullfilment
+    description: The Documents associated with the fullfilment object. For example in the case of online courses, it could represent a certificate of completion of a course.
     type: array
     items:
       $ref: "./Document.yaml"
@@ -47,6 +47,10 @@ properties:
   path:
     description: The physical path taken by the agent that can be rendered on a map. The allowed format of this property can be set by the network.
     type: string
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"
   tags:
     type: array
     items:

--- a/schema/Item.yaml
+++ b/schema/Item.yaml
@@ -105,6 +105,10 @@ properties:
   recommended:
     description: Whether this item is a recommended item to a response
     type: boolean
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"
   ttl:
     $ref: "./Duration.yaml"
   tags:

--- a/schema/MediaFile.yaml
+++ b/schema/MediaFile.yaml
@@ -1,7 +1,7 @@
 description: This object contains a url to a media file. 
 type: object
 properties:
-  mimetype:
+  mime_type:
     description: indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838
     type: string
   url:

--- a/schema/Order.yaml
+++ b/schema/Order.yaml
@@ -98,6 +98,10 @@ properties:
     description: The date-time of updated of this order
     type: string
     format: date-time
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"
   xinput:
     description: Additional input required from the customer to confirm this order
     allOf:

--- a/schema/Organization.yaml
+++ b/schema/Organization.yaml
@@ -17,3 +17,7 @@ properties:
     - $ref: "./City.yaml"
   contact:
     $ref: "./Contact.yaml"
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"

--- a/schema/Payment.yaml
+++ b/schema/Payment.yaml
@@ -54,4 +54,8 @@ properties:
     type: array
     items:
       $ref: "./TagGroup.yaml"
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"
 

--- a/schema/Price.yaml
+++ b/schema/Price.yaml
@@ -3,17 +3,28 @@ type: object
 properties:
   currency:
     type: string
+    description: Medium of exchange, traditional unit of payment, i.e. INR, USD etc.
   value:
     type: string
+    description: Monetary cost of an item, a decimal represented as string
   estimated_value:
     type: string
+    description: Monetary cost of an item, a decimal represented as string
   computed_value:
     type: string
+    description: Monetary cost of an item, a decimal represented as string
   listed_value:
     type: string
+    description: Monetary cost of an item, a decimal represented as string
   offered_value:
     type: string
+    description: Monetary cost of an item, a decimal represented as string
   minimum_value:
     type: string
+    description: Monetary cost of an item, a decimal represented as string
   maximum_value:
     type: string
+    description: Monetary cost of an item, a decimal represented as string
+  unit:
+    type: string
+    description: A unit of payment that can act as an instrument of exchange, i.e. carbon credit, bitcoin, etc.

--- a/schema/Provider.yaml
+++ b/schema/Provider.yaml
@@ -46,6 +46,10 @@ properties:
     type: boolean
   ttl:
     $ref: "./Duration.yaml"
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"
   tags:
     type: array
     items:

--- a/schema/Subscriber.yaml
+++ b/schema/Subscriber.yaml
@@ -23,3 +23,7 @@ properties:
     description: The region of operation of this subscriber
     allOf:
       - $ref: "./Location.yaml"
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"

--- a/schema/VC.yaml
+++ b/schema/VC.yaml
@@ -1,0 +1,88 @@
+description: Describes a Verifiable Credential
+type: object
+properties:
+  id:
+    description: A unique identifier for the credential (e.g., UUID or URI).
+    type: string
+  type:
+    description: Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.
+    type: array
+    items:
+      type: string
+  description:
+    $ref: "./Descriptor.yaml"
+  issuer:
+    type: object
+    description: "Entity that issued the credential"
+    properties:
+      description:
+        $ref: "./Descriptor.yaml"
+      address:
+        $ref: "./Address.yaml"
+      state:
+        $ref: "./State.yaml"
+      city:
+        $ref: "./City.yaml"
+      contact:
+        $ref: "./Contact.yaml"
+      registration_number:
+        type: string
+        description: "The registration number of the organization, if applicable."
+      website:
+        type: string
+        format: uri
+        description: "The official website of the issuing organization."
+  issueDate:
+    type: string
+    format: date-time
+    description: "The date when the credential was issued."
+  validFrom:
+    type: string
+    format: date-time
+    description: "The expiration date of the credential, if applicable."
+  validUntil:
+    type: string
+    format: date-time
+    description: "The expiration date of the credential, if applicable."
+  credentialSubject: #things about which claims are made. Example subjects include human beings, animals, and things.
+    type: array #Expressing information related to multiple subjects in a verifiable credential is possible, for example, 2 subjcts who ar spouses and, the credential is a relationship credential.
+    items:
+      properties:
+        id:
+          type: string
+        description:
+          $ref: "./Descriptor.yaml"
+        tags:
+          $ref: "./TagGroup.yaml"
+  claims:
+    type: array
+    items:
+      $ref: "./TagGroup.yaml"
+  proof:
+    type: object
+    description: "Cryptographic proof of the credential's authenticity"
+    properties:
+      created:
+        type: string
+        format: date-time
+        description: "Timestamp of when the proof was generated"
+      proofPurpose:
+        type: string
+        description: "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
+      type:
+        type: string
+        description: "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
+      verificationMethod:
+        type: string
+        description: "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
+      proofValue:
+        type: string
+        description: "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
+  termsOfUse:
+    type: array
+    items:
+      $ref: "./TagGroup.yaml"
+  status:
+    type: array
+    items:
+      $ref: "./Descriptor.yaml"

--- a/schema/VC.yaml
+++ b/schema/VC.yaml
@@ -1,11 +1,15 @@
 description: Describes a Verifiable Credential
 type: object
 properties:
+  context:
+    type: array
+    items:
+      type: string
   id:
     description: A unique identifier for the credential (e.g., UUID or URI).
     type: string
   type:
-    description: Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.
+    description: Types of the credential.
     type: array
     items:
       type: string
@@ -54,10 +58,14 @@ properties:
           $ref: "./Descriptor.yaml"
         tags:
           $ref: "./TagGroup.yaml"
-  claims:
+  credentialSchema:
     type: array
     items:
-      $ref: "./TagGroup.yaml"
+      properties:
+        id:
+          type: string
+        type:
+          type: string
   proof:
     type: object
     description: "Cryptographic proof of the credential's authenticity"

--- a/schema/VC.yaml
+++ b/schema/VC.yaml
@@ -45,7 +45,7 @@ properties:
     format: date-time
     description: "The expiration date of the credential, if applicable."
   credentialSubject: #things about which claims are made. Example subjects include human beings, animals, and things.
-    type: array #Expressing information related to multiple subjects in a verifiable credential is possible, for example, 2 subjcts who ar spouses and, the credential is a relationship credential.
+    type: array #Expressing information related to multiple subjects in a verifiable credential is possible, for example, 2 subjcts who are spouses and, the credential is a relationship credential.
     items:
       properties:
         id:
@@ -82,7 +82,11 @@ properties:
     type: array
     items:
       $ref: "./TagGroup.yaml"
-  status:
+  credentialStatus:
     type: array
     items:
       $ref: "./Descriptor.yaml"
+  evidence: # The evidence property is used to express supporting information, such as documentary evidence, related to the verifiable credential.
+    type: array
+    items:
+      $ref: "./TagGroup.yaml"


### PR DESCRIPTION
### Description
The Hyperbeckn is a decentralized infrastructure designed to transform how participants build trust and transact in a secure, scalable, and transparent environment. The goal is to embed trust into the flow of transactions. 

To do so, it is essential to have a Credential object in the transaction flow. This Credential object must support various types of credentials and it needs to be included in various components used in transaction, like Agent, Customer, Organisation, Payment, Provider, Subscriber, Fulfillment, Item, Order etc.

### Summary of the changes proposed
There already is a Credential schema defined in the protocol specification. As part  of this PR the existing Credential Object was enhanced to support various type of credentials, including a [Verifiable Credentials](https://www.w3.org/TR/vc-data-model-2.0/)

Two new API endpoints ( cred/ and on_cred/) were added in the protocol specification to support fetching credentials.

### Changes

1. Addition: Created ```schema/VC.yaml``` to represent a verifiable credential object.
2. Update: Changed ```schema/Credential.yaml``` to support Verifiable Credentials
3. Addition: Created ```schema/CredentialRequest.yaml``` schema to represent a credential request object.
4. Addition: created ```cred/``` endpoint to be used to request a credential from an entity
5. Addition: created ```on_cred/``` endpoint to be used as callback to provide the requested credentials.
6. Addition: Added a boolean ```verified``` field in the context schema