### PR TITLE
Enhance the context schema to have a verified (true / false) flag 

### DIFF
--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -989,6 +989,9 @@ components:
           type: string
         ttl:
           $ref: '#/components/schemas/Duration'
+        verified:
+          description: 'Indicates whether the entity is verified. A value of true means the entity has successfully completed the verification process, while false indicates that the entity is either unverified or has failed verification.'
+          type: boolean
     Country:
       description: Describes a country
       type: object

--- a/schema/Context.yaml
+++ b/schema/Context.yaml
@@ -48,4 +48,7 @@ properties:
     type: string
   ttl:
     $ref: "./Duration.yaml"
+  verified:
+    description: Indicates whether the entity is verified. A value of true means the entity has successfully completed the verification process, while false indicates that the entity is either unverified or has failed verification.
+    type: boolean
 


### PR DESCRIPTION
### Changes Introduced
Added a boolean ```verified``` Field in the Context schema of the core protocol specification.

Type: boolean
Description: Indicates if an entity is verified or not. A value of ```true``` means the entity is verified, while ```false``` indicates the entity is either unverified or verification could not be completed.

### Context of the change
**Motivation**
This change is part of the credentials schema updates aimed at inducing trust in the transaction flow. The addition of the ```verified``` field strengthens the system’s ability to distinguish between verified and unverified entities.

### Migration Impact

The changes are fully backward compatible. All modifications involved either the creation of new schemas or the addition of new fields to existing schemas.