### PR TITLE
Define a schema for the beckn.json document

### DIFF
--- a/api/about-endpoint/README.md
+++ b/api/about-endpoint/README.md
@@ -1,0 +1,20 @@
+### Steps to generate beckn.json file
+
+1. Make sure we have api/about.json.
+
+2. Generate verifiableCredential json from schema/credential.yaml
+
+```json-dereference -s schema/Credential.yaml -o api/about-endpoint/becknVerifiableCredential.json```
+
+3. The generate document is just a json file, to make it a json schema definition, add the below lines manually in the ```api/about-endpoint/becknVerifiableCredential.json``` at the root of the object. 
+
+```
+"$id": "becknVerifiableCredential",
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+```
+
+4. Genearte beckn.json using about.json
+
+```
+json-dereference -s api/about-endpoint/about.json -o api/about-endpoint/beckn.json
+```

--- a/api/about-endpoint/README.md
+++ b/api/about-endpoint/README.md
@@ -1,20 +1,24 @@
 ### Steps to generate beckn.json file
 
-1. Make sure we have api/about.json.
+1. install ```json-dereference-cli```
 
-2. Generate verifiableCredential json from schema/credential.yaml
+    ```npm install -g json-dereference-cli```
 
-```json-dereference -s schema/Credential.yaml -o api/about-endpoint/becknVerifiableCredential.json```
+2. Make sure we have api/about.json.
 
-3. The generate document is just a json file, to make it a json schema definition, add the below lines manually in the ```api/about-endpoint/becknVerifiableCredential.json``` at the root of the object. 
+3. Generate verifiableCredential json from schema/credential.yaml
 
-```
-"$id": "becknVerifiableCredential",
-"$schema": "https://json-schema.org/draft/2020-12/schema"
-```
+    ```json-dereference -s schema/Credential.yaml -o api/about-endpoint/becknVerifiableCredential.json```
 
-4. Genearte beckn.json using about.json
+4. The generate document is just a json file, to make it a json schema definition, add the below lines manually in the ```api/about-endpoint/becknVerifiableCredential.json``` at the root of the object.
 
-```
-json-dereference -s api/about-endpoint/about.json -o api/about-endpoint/beckn.json
-```
+    ```
+    "$id": "becknVerifiableCredential",
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+    ```
+
+5. Genearte beckn.json using about.json
+
+    ```
+    json-dereference -s api/about-endpoint/about.json -o api/about-endpoint/beckn.json
+    ```

--- a/api/about-endpoint/about.json
+++ b/api/about-endpoint/about.json
@@ -1,0 +1,18 @@
+{
+    "$id": "aboutSchema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Json schema describing the structure of beckn.json",
+    "type": "object",
+    "properties": {
+        "credentials": {
+            "type": "array",
+            "items": {
+                "$ref": "becknVerifiableCredential.json#"
+            }
+        },
+        "layer2Config": {
+            "type": "string",
+            "format": "url"
+        }
+    }
+}

--- a/api/about-endpoint/beckn.json
+++ b/api/about-endpoint/beckn.json
@@ -289,1198 +289,183 @@
                                 }
                             },
                             "description": {
-                                "description": "Physical description of something.",
-                                "type": "object",
-                                "properties": {
-                                    "name": {
+                                "anyOf": [
+                                    {
                                         "type": "string"
                                     },
-                                    "code": {
-                                        "type": "string"
+                                    {
+                                        "type": "object"
                                     },
-                                    "short_desc": {
-                                        "type": "string"
-                                    },
-                                    "long_desc": {
-                                        "type": "string"
-                                    },
-                                    "additional_desc": {
-                                        "type": "object",
-                                        "properties": {
-                                            "url": {
-                                                "type": "string"
-                                            },
-                                            "content_type": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "text/plain",
-                                                    "text/html",
-                                                    "application/json"
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    "media": {
+                                    {
                                         "type": "array",
                                         "items": {
-                                            "description": "This object contains a url to a media file.",
-                                            "type": "object",
-                                            "properties": {
-                                                "mimetype": {
-                                                    "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                    "type": "string"
-                                                },
-                                                "url": {
-                                                    "description": "The URL of the file",
-                                                    "type": "string",
-                                                    "format": "uri"
-                                                },
-                                                "signature": {
-                                                    "description": "The digital signature of the file signed by the sender",
-                                                    "type": "string"
-                                                },
-                                                "dsa": {
-                                                    "description": "The signing algorithm used by the sender",
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "images": {
-                                        "type": "array",
-                                        "items": {
-                                            "description": "Describes an image",
-                                            "type": "object",
-                                            "properties": {
-                                                "url": {
-                                                    "description": "URL to the image. This can be a data url or an remote url",
-                                                    "type": "string",
-                                                    "format": "uri"
-                                                },
-                                                "size_type": {
-                                                    "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                    "type": "string",
-                                                    "enum": [
-                                                        "xs",
-                                                        "sm",
-                                                        "md",
-                                                        "lg",
-                                                        "xl",
-                                                        "custom"
-                                                    ]
-                                                },
-                                                "width": {
-                                                    "description": "Width of the image in pixels",
-                                                    "type": "string"
-                                                },
-                                                "height": {
-                                                    "description": "Height of the image in pixels",
-                                                    "type": "string"
-                                                }
-                                            }
+                                            "type": "object"
                                         }
                                     }
-                                }
+                                ]
                             },
                             "issuer": {
-                                "type": "object",
-                                "description": "Entity that issued the credential",
-                                "properties": {
-                                    "description": {
-                                        "description": "Physical description of something.",
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {
-                                                "type": "string"
-                                            },
-                                            "code": {
-                                                "type": "string"
-                                            },
-                                            "short_desc": {
-                                                "type": "string"
-                                            },
-                                            "long_desc": {
-                                                "type": "string"
-                                            },
-                                            "additional_desc": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "url": {
-                                                        "type": "string"
-                                                    },
-                                                    "content_type": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "text/plain",
-                                                            "text/html",
-                                                            "application/json"
-                                                        ]
-                                                    }
-                                                }
-                                            },
-                                            "media": {
-                                                "type": "array",
-                                                "items": {
-                                                    "description": "This object contains a url to a media file.",
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "mimetype": {
-                                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                            "type": "string"
-                                                        },
-                                                        "url": {
-                                                            "description": "The URL of the file",
-                                                            "type": "string",
-                                                            "format": "uri"
-                                                        },
-                                                        "signature": {
-                                                            "description": "The digital signature of the file signed by the sender",
-                                                            "type": "string"
-                                                        },
-                                                        "dsa": {
-                                                            "description": "The signing algorithm used by the sender",
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            "images": {
-                                                "type": "array",
-                                                "items": {
-                                                    "description": "Describes an image",
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "url": {
-                                                            "description": "URL to the image. This can be a data url or an remote url",
-                                                            "type": "string",
-                                                            "format": "uri"
-                                                        },
-                                                        "size_type": {
-                                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                            "type": "string",
-                                                            "enum": [
-                                                                "xs",
-                                                                "sm",
-                                                                "md",
-                                                                "lg",
-                                                                "xl",
-                                                                "custom"
-                                                            ]
-                                                        },
-                                                        "width": {
-                                                            "description": "Width of the image in pixels",
-                                                            "type": "string"
-                                                        },
-                                                        "height": {
-                                                            "description": "Height of the image in pixels",
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "address": {
-                                        "description": "Describes a postal address.",
+                                "anyOf": [
+                                    {
                                         "type": "string"
                                     },
-                                    "state": {
-                                        "description": "A bounded geopolitical region of governance inside a country.",
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {
-                                                "type": "string",
-                                                "description": "Name of the state"
-                                            },
-                                            "code": {
-                                                "type": "string",
-                                                "description": "State code as per country or international standards"
-                                            }
-                                        }
-                                    },
-                                    "city": {
-                                        "description": "Describes a city",
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {
-                                                "description": "Name of the city",
-                                                "type": "string"
-                                            },
-                                            "code": {
-                                                "description": "City code",
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "contact": {
-                                        "description": "Describes the contact information of an entity",
-                                        "type": "object",
-                                        "properties": {
-                                            "phone": {
-                                                "type": "string"
-                                            },
-                                            "email": {
-                                                "type": "string"
-                                            },
-                                            "jcard": {
-                                                "type": "object",
-                                                "description": "A Jcard object as per draft-ietf-jcardcal-jcard-03 specification"
-                                            }
-                                        }
-                                    },
-                                    "registration_number": {
-                                        "type": "string",
-                                        "description": "The registration number of the organization, if applicable."
-                                    },
-                                    "website": {
-                                        "type": "string",
-                                        "format": "uri",
-                                        "description": "The official website of the issuing organization."
+                                    {
+                                        "type": "object"
                                     }
-                                }
+                                ]
                             },
-                            "issueDate": {
+                            "issuanceDate": {
                                 "type": "string",
-                                "format": "date-time",
                                 "description": "The date when the credential was issued."
                             },
                             "validFrom": {
                                 "type": "string",
-                                "format": "date-time",
                                 "description": "The expiration date of the credential, if applicable."
                             },
                             "validUntil": {
                                 "type": "string",
-                                "format": "date-time",
                                 "description": "The expiration date of the credential, if applicable."
                             },
                             "credentialSubject": {
-                                "type": "array",
-                                "items": {
-                                    "properties": {
-                                        "id": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
                                             "type": "string"
-                                        },
-                                        "description": {
-                                            "description": "Physical description of something.",
-                                            "type": "object",
-                                            "properties": {
-                                                "name": {
-                                                    "type": "string"
-                                                },
-                                                "code": {
-                                                    "type": "string"
-                                                },
-                                                "short_desc": {
-                                                    "type": "string"
-                                                },
-                                                "long_desc": {
-                                                    "type": "string"
-                                                },
-                                                "additional_desc": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "url": {
-                                                            "type": "string"
-                                                        },
-                                                        "content_type": {
-                                                            "type": "string",
-                                                            "enum": [
-                                                                "text/plain",
-                                                                "text/html",
-                                                                "application/json"
-                                                            ]
-                                                        }
-                                                    }
-                                                },
-                                                "media": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "description": "This object contains a url to a media file.",
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "mimetype": {
-                                                                "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                                "type": "string"
-                                                            },
-                                                            "url": {
-                                                                "description": "The URL of the file",
-                                                                "type": "string",
-                                                                "format": "uri"
-                                                            },
-                                                            "signature": {
-                                                                "description": "The digital signature of the file signed by the sender",
-                                                                "type": "string"
-                                                            },
-                                                            "dsa": {
-                                                                "description": "The signing algorithm used by the sender",
-                                                                "type": "string"
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                "images": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "description": "Describes an image",
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "url": {
-                                                                "description": "URL to the image. This can be a data url or an remote url",
-                                                                "type": "string",
-                                                                "format": "uri"
-                                                            },
-                                                            "size_type": {
-                                                                "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "xs",
-                                                                    "sm",
-                                                                    "md",
-                                                                    "lg",
-                                                                    "xl",
-                                                                    "custom"
-                                                                ]
-                                                            },
-                                                            "width": {
-                                                                "description": "Width of the image in pixels",
-                                                                "type": "string"
-                                                            },
-                                                            "height": {
-                                                                "description": "Height of the image in pixels",
-                                                                "type": "string"
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "tags": {
-                                            "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
-                                            "type": "object",
-                                            "properties": {
-                                                "display": {
-                                                    "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
-                                                    "type": "boolean",
-                                                    "default": true
-                                                },
-                                                "descriptor": {
-                                                    "description": "Description of the TagGroup, can be used to store detailed information.",
-                                                    "allOf": [
-                                                        {
-                                                            "description": "Physical description of something.",
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "name": {
-                                                                    "type": "string"
-                                                                },
-                                                                "code": {
-                                                                    "type": "string"
-                                                                },
-                                                                "short_desc": {
-                                                                    "type": "string"
-                                                                },
-                                                                "long_desc": {
-                                                                    "type": "string"
-                                                                },
-                                                                "additional_desc": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "url": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "content_type": {
-                                                                            "type": "string",
-                                                                            "enum": [
-                                                                                "text/plain",
-                                                                                "text/html",
-                                                                                "application/json"
-                                                                            ]
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "media": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "description": "This object contains a url to a media file.",
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "mimetype": {
-                                                                                "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                                                "type": "string"
-                                                                            },
-                                                                            "url": {
-                                                                                "description": "The URL of the file",
-                                                                                "type": "string",
-                                                                                "format": "uri"
-                                                                            },
-                                                                            "signature": {
-                                                                                "description": "The digital signature of the file signed by the sender",
-                                                                                "type": "string"
-                                                                            },
-                                                                            "dsa": {
-                                                                                "description": "The signing algorithm used by the sender",
-                                                                                "type": "string"
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "images": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "description": "Describes an image",
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "url": {
-                                                                                "description": "URL to the image. This can be a data url or an remote url",
-                                                                                "type": "string",
-                                                                                "format": "uri"
-                                                                            },
-                                                                            "size_type": {
-                                                                                "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                                                "type": "string",
-                                                                                "enum": [
-                                                                                    "xs",
-                                                                                    "sm",
-                                                                                    "md",
-                                                                                    "lg",
-                                                                                    "xl",
-                                                                                    "custom"
-                                                                                ]
-                                                                            },
-                                                                            "width": {
-                                                                                "description": "Width of the image in pixels",
-                                                                                "type": "string"
-                                                                            },
-                                                                            "height": {
-                                                                                "description": "Height of the image in pixels",
-                                                                                "type": "string"
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                "list": {
-                                                    "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
-                                                    "type": "array",
-                                                    "items": {
-                                                        "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "descriptor": {
-                                                                "description": "Description of the Tag, can be used to store detailed information.",
-                                                                "allOf": [
-                                                                    {
-                                                                        "description": "Physical description of something.",
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "name": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "code": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "short_desc": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "long_desc": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "additional_desc": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "url": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "content_type": {
-                                                                                        "type": "string",
-                                                                                        "enum": [
-                                                                                            "text/plain",
-                                                                                            "text/html",
-                                                                                            "application/json"
-                                                                                        ]
-                                                                                    }
-                                                                                }
-                                                                            },
-                                                                            "media": {
-                                                                                "type": "array",
-                                                                                "items": {
-                                                                                    "description": "This object contains a url to a media file.",
-                                                                                    "type": "object",
-                                                                                    "properties": {
-                                                                                        "mimetype": {
-                                                                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                                                            "type": "string"
-                                                                                        },
-                                                                                        "url": {
-                                                                                            "description": "The URL of the file",
-                                                                                            "type": "string",
-                                                                                            "format": "uri"
-                                                                                        },
-                                                                                        "signature": {
-                                                                                            "description": "The digital signature of the file signed by the sender",
-                                                                                            "type": "string"
-                                                                                        },
-                                                                                        "dsa": {
-                                                                                            "description": "The signing algorithm used by the sender",
-                                                                                            "type": "string"
-                                                                                        }
-                                                                                    }
-                                                                                }
-                                                                            },
-                                                                            "images": {
-                                                                                "type": "array",
-                                                                                "items": {
-                                                                                    "description": "Describes an image",
-                                                                                    "type": "object",
-                                                                                    "properties": {
-                                                                                        "url": {
-                                                                                            "description": "URL to the image. This can be a data url or an remote url",
-                                                                                            "type": "string",
-                                                                                            "format": "uri"
-                                                                                        },
-                                                                                        "size_type": {
-                                                                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                                                            "type": "string",
-                                                                                            "enum": [
-                                                                                                "xs",
-                                                                                                "sm",
-                                                                                                "md",
-                                                                                                "lg",
-                                                                                                "xl",
-                                                                                                "custom"
-                                                                                            ]
-                                                                                        },
-                                                                                        "width": {
-                                                                                            "description": "Width of the image in pixels",
-                                                                                            "type": "string"
-                                                                                        },
-                                                                                        "height": {
-                                                                                            "description": "Height of the image in pixels",
-                                                                                            "type": "string"
-                                                                                        }
-                                                                                    }
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                ]
-                                                            },
-                                                            "value": {
-                                                                "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
-                                                                "type": "string"
-                                                            },
-                                                            "display": {
-                                                                "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
-                                                                "type": "boolean"
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object"
                                         }
                                     }
-                                }
+                                ]
                             },
                             "credentialSchema": {
-                                "type": "array",
-                                "items": {
-                                    "properties": {
-                                        "id": {
-                                            "type": "string"
-                                        },
-                                        "type": {
-                                            "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object"
                                         }
                                     }
-                                }
+                                ]
                             },
                             "proof": {
-                                "type": "object",
-                                "description": "Cryptographic proof of the credential's authenticity",
-                                "properties": {
-                                    "created": {
-                                        "type": "string",
-                                        "format": "date-time",
-                                        "description": "Timestamp of when the proof was generated"
+                                "anyOf": [
+                                    {
+                                        "type": "object",
+                                        "description": "Cryptographic proof of the credential's authenticity",
+                                        "properties": {
+                                            "created": {
+                                                "type": "string",
+                                                "format": "date-time",
+                                                "description": "Timestamp of when the proof was generated"
+                                            },
+                                            "proofPurpose": {
+                                                "type": "string",
+                                                "description": "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
+                                            },
+                                            "type": {
+                                                "type": "string",
+                                                "description": "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
+                                            },
+                                            "verificationMethod": {
+                                                "type": "string",
+                                                "description": "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
+                                            },
+                                            "proofValue": {
+                                                "type": "string",
+                                                "description": "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
+                                            }
+                                        }
                                     },
-                                    "proofPurpose": {
-                                        "type": "string",
-                                        "description": "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
-                                    },
-                                    "type": {
-                                        "type": "string",
-                                        "description": "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
-                                    },
-                                    "verificationMethod": {
-                                        "type": "string",
-                                        "description": "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
-                                    },
-                                    "proofValue": {
-                                        "type": "string",
-                                        "description": "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object"
+                                        }
                                     }
-                                }
+                                ]
                             },
                             "termsOfUse": {
-                                "type": "array",
-                                "items": {
-                                    "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
-                                    "type": "object",
-                                    "properties": {
-                                        "display": {
-                                            "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
-                                            "type": "boolean",
-                                            "default": true
-                                        },
-                                        "descriptor": {
-                                            "description": "Description of the TagGroup, can be used to store detailed information.",
-                                            "allOf": [
-                                                {
-                                                    "description": "Physical description of something.",
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "code": {
-                                                            "type": "string"
-                                                        },
-                                                        "short_desc": {
-                                                            "type": "string"
-                                                        },
-                                                        "long_desc": {
-                                                            "type": "string"
-                                                        },
-                                                        "additional_desc": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "url": {
-                                                                    "type": "string"
-                                                                },
-                                                                "content_type": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "text/plain",
-                                                                        "text/html",
-                                                                        "application/json"
-                                                                    ]
-                                                                }
-                                                            }
-                                                        },
-                                                        "media": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "description": "This object contains a url to a media file.",
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "mimetype": {
-                                                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "url": {
-                                                                        "description": "The URL of the file",
-                                                                        "type": "string",
-                                                                        "format": "uri"
-                                                                    },
-                                                                    "signature": {
-                                                                        "description": "The digital signature of the file signed by the sender",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "dsa": {
-                                                                        "description": "The signing algorithm used by the sender",
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "images": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "description": "Describes an image",
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "url": {
-                                                                        "description": "URL to the image. This can be a data url or an remote url",
-                                                                        "type": "string",
-                                                                        "format": "uri"
-                                                                    },
-                                                                    "size_type": {
-                                                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "xs",
-                                                                            "sm",
-                                                                            "md",
-                                                                            "lg",
-                                                                            "xl",
-                                                                            "custom"
-                                                                        ]
-                                                                    },
-                                                                    "width": {
-                                                                        "description": "Width of the image in pixels",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "height": {
-                                                                        "description": "Height of the image in pixels",
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "list": {
-                                            "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
-                                            "type": "array",
-                                            "items": {
-                                                "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
-                                                "type": "object",
-                                                "properties": {
-                                                    "descriptor": {
-                                                        "description": "Description of the Tag, can be used to store detailed information.",
-                                                        "allOf": [
-                                                            {
-                                                                "description": "Physical description of something.",
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "name": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "code": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "short_desc": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "long_desc": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "additional_desc": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "url": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "content_type": {
-                                                                                "type": "string",
-                                                                                "enum": [
-                                                                                    "text/plain",
-                                                                                    "text/html",
-                                                                                    "application/json"
-                                                                                ]
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "media": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "description": "This object contains a url to a media file.",
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "mimetype": {
-                                                                                    "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "url": {
-                                                                                    "description": "The URL of the file",
-                                                                                    "type": "string",
-                                                                                    "format": "uri"
-                                                                                },
-                                                                                "signature": {
-                                                                                    "description": "The digital signature of the file signed by the sender",
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "dsa": {
-                                                                                    "description": "The signing algorithm used by the sender",
-                                                                                    "type": "string"
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "images": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "description": "Describes an image",
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "url": {
-                                                                                    "description": "URL to the image. This can be a data url or an remote url",
-                                                                                    "type": "string",
-                                                                                    "format": "uri"
-                                                                                },
-                                                                                "size_type": {
-                                                                                    "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "xs",
-                                                                                        "sm",
-                                                                                        "md",
-                                                                                        "lg",
-                                                                                        "xl",
-                                                                                        "custom"
-                                                                                    ]
-                                                                                },
-                                                                                "width": {
-                                                                                    "description": "Width of the image in pixels",
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "height": {
-                                                                                    "description": "Height of the image in pixels",
-                                                                                    "type": "string"
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    "value": {
-                                                        "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
-                                                        "type": "string"
-                                                    },
-                                                    "display": {
-                                                        "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
-                                                        "type": "boolean"
-                                                    }
-                                                }
-                                            }
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object"
                                         }
                                     }
-                                }
+                                ]
                             },
                             "credentialStatus": {
-                                "type": "array",
-                                "items": {
-                                    "description": "Physical description of something.",
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
                                             "type": "string"
-                                        },
-                                        "code": {
-                                            "type": "string"
-                                        },
-                                        "short_desc": {
-                                            "type": "string"
-                                        },
-                                        "long_desc": {
-                                            "type": "string"
-                                        },
-                                        "additional_desc": {
-                                            "type": "object",
-                                            "properties": {
-                                                "url": {
-                                                    "type": "string"
-                                                },
-                                                "content_type": {
-                                                    "type": "string",
-                                                    "enum": [
-                                                        "text/plain",
-                                                        "text/html",
-                                                        "application/json"
-                                                    ]
-                                                }
-                                            }
-                                        },
-                                        "media": {
-                                            "type": "array",
-                                            "items": {
-                                                "description": "This object contains a url to a media file.",
-                                                "type": "object",
-                                                "properties": {
-                                                    "mimetype": {
-                                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                        "type": "string"
-                                                    },
-                                                    "url": {
-                                                        "description": "The URL of the file",
-                                                        "type": "string",
-                                                        "format": "uri"
-                                                    },
-                                                    "signature": {
-                                                        "description": "The digital signature of the file signed by the sender",
-                                                        "type": "string"
-                                                    },
-                                                    "dsa": {
-                                                        "description": "The signing algorithm used by the sender",
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "images": {
-                                            "type": "array",
-                                            "items": {
-                                                "description": "Describes an image",
-                                                "type": "object",
-                                                "properties": {
-                                                    "url": {
-                                                        "description": "URL to the image. This can be a data url or an remote url",
-                                                        "type": "string",
-                                                        "format": "uri"
-                                                    },
-                                                    "size_type": {
-                                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "xs",
-                                                            "sm",
-                                                            "md",
-                                                            "lg",
-                                                            "xl",
-                                                            "custom"
-                                                        ]
-                                                    },
-                                                    "width": {
-                                                        "description": "Width of the image in pixels",
-                                                        "type": "string"
-                                                    },
-                                                    "height": {
-                                                        "description": "Height of the image in pixels",
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object"
                                         }
                                     }
-                                }
+                                ]
                             },
                             "evidence": {
-                                "type": "array",
-                                "items": {
-                                    "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
-                                    "type": "object",
-                                    "properties": {
-                                        "display": {
-                                            "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
-                                            "type": "boolean",
-                                            "default": true
-                                        },
-                                        "descriptor": {
-                                            "description": "Description of the TagGroup, can be used to store detailed information.",
-                                            "allOf": [
-                                                {
-                                                    "description": "Physical description of something.",
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "code": {
-                                                            "type": "string"
-                                                        },
-                                                        "short_desc": {
-                                                            "type": "string"
-                                                        },
-                                                        "long_desc": {
-                                                            "type": "string"
-                                                        },
-                                                        "additional_desc": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "url": {
-                                                                    "type": "string"
-                                                                },
-                                                                "content_type": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "text/plain",
-                                                                        "text/html",
-                                                                        "application/json"
-                                                                    ]
-                                                                }
-                                                            }
-                                                        },
-                                                        "media": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "description": "This object contains a url to a media file.",
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "mimetype": {
-                                                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "url": {
-                                                                        "description": "The URL of the file",
-                                                                        "type": "string",
-                                                                        "format": "uri"
-                                                                    },
-                                                                    "signature": {
-                                                                        "description": "The digital signature of the file signed by the sender",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "dsa": {
-                                                                        "description": "The signing algorithm used by the sender",
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "images": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "description": "Describes an image",
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "url": {
-                                                                        "description": "URL to the image. This can be a data url or an remote url",
-                                                                        "type": "string",
-                                                                        "format": "uri"
-                                                                    },
-                                                                    "size_type": {
-                                                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "xs",
-                                                                            "sm",
-                                                                            "md",
-                                                                            "lg",
-                                                                            "xl",
-                                                                            "custom"
-                                                                        ]
-                                                                    },
-                                                                    "width": {
-                                                                        "description": "Width of the image in pixels",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "height": {
-                                                                        "description": "Height of the image in pixels",
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "list": {
-                                            "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
-                                            "type": "array",
-                                            "items": {
-                                                "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
-                                                "type": "object",
-                                                "properties": {
-                                                    "descriptor": {
-                                                        "description": "Description of the Tag, can be used to store detailed information.",
-                                                        "allOf": [
-                                                            {
-                                                                "description": "Physical description of something.",
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "name": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "code": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "short_desc": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "long_desc": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "additional_desc": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "url": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "content_type": {
-                                                                                "type": "string",
-                                                                                "enum": [
-                                                                                    "text/plain",
-                                                                                    "text/html",
-                                                                                    "application/json"
-                                                                                ]
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "media": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "description": "This object contains a url to a media file.",
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "mimetype": {
-                                                                                    "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "url": {
-                                                                                    "description": "The URL of the file",
-                                                                                    "type": "string",
-                                                                                    "format": "uri"
-                                                                                },
-                                                                                "signature": {
-                                                                                    "description": "The digital signature of the file signed by the sender",
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "dsa": {
-                                                                                    "description": "The signing algorithm used by the sender",
-                                                                                    "type": "string"
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "images": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "description": "Describes an image",
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "url": {
-                                                                                    "description": "URL to the image. This can be a data url or an remote url",
-                                                                                    "type": "string",
-                                                                                    "format": "uri"
-                                                                                },
-                                                                                "size_type": {
-                                                                                    "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "xs",
-                                                                                        "sm",
-                                                                                        "md",
-                                                                                        "lg",
-                                                                                        "xl",
-                                                                                        "custom"
-                                                                                    ]
-                                                                                },
-                                                                                "width": {
-                                                                                    "description": "Width of the image in pixels",
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "height": {
-                                                                                    "description": "Height of the image in pixels",
-                                                                                    "type": "string"
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    "value": {
-                                                        "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
-                                                        "type": "string"
-                                                    },
-                                                    "display": {
-                                                        "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
-                                                        "type": "boolean"
-                                                    }
-                                                }
-                                            }
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object"
                                         }
                                     }
-                                }
+                                ]
+                            },
+                            "credentialHash": {
+                                "type": "string"
                             }
                         }
                     }

--- a/api/about-endpoint/beckn.json
+++ b/api/about-endpoint/beckn.json
@@ -271,7 +271,7 @@
                         "description": "Describes a Verifiable Credential",
                         "type": "object",
                         "properties": {
-                            "context": {
+                            "@context": {
                                 "type": "array",
                                 "items": {
                                     "type": "string"
@@ -364,31 +364,7 @@
                             "proof": {
                                 "anyOf": [
                                     {
-                                        "type": "object",
-                                        "description": "Cryptographic proof of the credential's authenticity",
-                                        "properties": {
-                                            "created": {
-                                                "type": "string",
-                                                "format": "date-time",
-                                                "description": "Timestamp of when the proof was generated"
-                                            },
-                                            "proofPurpose": {
-                                                "type": "string",
-                                                "description": "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
-                                            },
-                                            "type": {
-                                                "type": "string",
-                                                "description": "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
-                                            },
-                                            "verificationMethod": {
-                                                "type": "string",
-                                                "description": "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
-                                            },
-                                            "proofValue": {
-                                                "type": "string",
-                                                "description": "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
-                                            }
-                                        }
+                                        "type": "object"
                                     },
                                     {
                                         "type": "array",

--- a/api/about-endpoint/beckn.json
+++ b/api/about-endpoint/beckn.json
@@ -1,0 +1,1495 @@
+{
+    "$id": "aboutSchema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Json schema describing the structure of beckn.json",
+    "type": "object",
+    "properties": {
+        "credentials": {
+            "type": "array",
+            "items": {
+                "$id": "becknVerifiableCredential",
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "description": "Describes a credential of an entity - Person, Organization, Item, Payment etc",
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Physical description of something.",
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "code": {
+                                "type": "string"
+                            },
+                            "short_desc": {
+                                "type": "string"
+                            },
+                            "long_desc": {
+                                "type": "string"
+                            },
+                            "additional_desc": {
+                                "type": "object",
+                                "properties": {
+                                    "url": {
+                                        "type": "string"
+                                    },
+                                    "content_type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "text/plain",
+                                            "text/html",
+                                            "application/json"
+                                        ]
+                                    }
+                                }
+                            },
+                            "media": {
+                                "type": "array",
+                                "items": {
+                                    "description": "This object contains a url to a media file.",
+                                    "type": "object",
+                                    "properties": {
+                                        "mimetype": {
+                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                            "type": "string"
+                                        },
+                                        "url": {
+                                            "description": "The URL of the file",
+                                            "type": "string",
+                                            "format": "uri"
+                                        },
+                                        "signature": {
+                                            "description": "The digital signature of the file signed by the sender",
+                                            "type": "string"
+                                        },
+                                        "dsa": {
+                                            "description": "The signing algorithm used by the sender",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "images": {
+                                "type": "array",
+                                "items": {
+                                    "description": "Describes an image",
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {
+                                            "description": "URL to the image. This can be a data url or an remote url",
+                                            "type": "string",
+                                            "format": "uri"
+                                        },
+                                        "size_type": {
+                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                            "type": "string",
+                                            "enum": [
+                                                "xs",
+                                                "sm",
+                                                "md",
+                                                "lg",
+                                                "xl",
+                                                "custom"
+                                            ]
+                                        },
+                                        "width": {
+                                            "description": "Width of the image in pixels",
+                                            "type": "string"
+                                        },
+                                        "height": {
+                                            "description": "Height of the image in pixels",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "docs": {
+                        "description": "The Documents associated with the credential.",
+                        "type": "array",
+                        "items": {
+                            "description": "Describes a document which can be sent as a url",
+                            "type": "object",
+                            "properties": {
+                                "descriptor": {
+                                    "description": "Physical description of something.",
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "short_desc": {
+                                            "type": "string"
+                                        },
+                                        "long_desc": {
+                                            "type": "string"
+                                        },
+                                        "additional_desc": {
+                                            "type": "object",
+                                            "properties": {
+                                                "url": {
+                                                    "type": "string"
+                                                },
+                                                "content_type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "text/plain",
+                                                        "text/html",
+                                                        "application/json"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "media": {
+                                            "type": "array",
+                                            "items": {
+                                                "description": "This object contains a url to a media file.",
+                                                "type": "object",
+                                                "properties": {
+                                                    "mimetype": {
+                                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                        "type": "string"
+                                                    },
+                                                    "url": {
+                                                        "description": "The URL of the file",
+                                                        "type": "string",
+                                                        "format": "uri"
+                                                    },
+                                                    "signature": {
+                                                        "description": "The digital signature of the file signed by the sender",
+                                                        "type": "string"
+                                                    },
+                                                    "dsa": {
+                                                        "description": "The signing algorithm used by the sender",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "images": {
+                                            "type": "array",
+                                            "items": {
+                                                "description": "Describes an image",
+                                                "type": "object",
+                                                "properties": {
+                                                    "url": {
+                                                        "description": "URL to the image. This can be a data url or an remote url",
+                                                        "type": "string",
+                                                        "format": "uri"
+                                                    },
+                                                    "size_type": {
+                                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "xs",
+                                                            "sm",
+                                                            "md",
+                                                            "lg",
+                                                            "xl",
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "width": {
+                                                        "description": "Width of the image in pixels",
+                                                        "type": "string"
+                                                    },
+                                                    "height": {
+                                                        "description": "Height of the image in pixels",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "url": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "label": {
+                                    "type": "string"
+                                },
+                                "mime_type": {
+                                    "description": "Describes the contents of the uri field. If the value is text/html, it is recommended for the BAP to render the contents inside a webview. This generally does not render a good user experience on the BAP, hence the payment page developers are recommended to develop their payment pages in a mobile-friendly manner.",
+                                    "type": "string",
+                                    "enum": [
+                                        "application/pdf",
+                                        "text/plain",
+                                        "image/jpeg",
+                                        "video/mp4",
+                                        "audio/wav",
+                                        "application/zip"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "media": {
+                        "description": "The Media associated with the credential.",
+                        "type": "array",
+                        "items": {
+                            "description": "This object contains a url to a media file.",
+                            "type": "object",
+                            "properties": {
+                                "mimetype": {
+                                    "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "description": "The URL of the file",
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "signature": {
+                                    "description": "The digital signature of the file signed by the sender",
+                                    "type": "string"
+                                },
+                                "dsa": {
+                                    "description": "The signing algorithm used by the sender",
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "url": {
+                        "description": "URL of the credential",
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "verifiableCredential": {
+                        "description": "Describes a Verifiable Credential",
+                        "type": "object",
+                        "properties": {
+                            "context": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "id": {
+                                "description": "A unique identifier for the credential (e.g., UUID or URI).",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Types of the credential.",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "description": {
+                                "description": "Physical description of something.",
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    },
+                                    "short_desc": {
+                                        "type": "string"
+                                    },
+                                    "long_desc": {
+                                        "type": "string"
+                                    },
+                                    "additional_desc": {
+                                        "type": "object",
+                                        "properties": {
+                                            "url": {
+                                                "type": "string"
+                                            },
+                                            "content_type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text/plain",
+                                                    "text/html",
+                                                    "application/json"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "media": {
+                                        "type": "array",
+                                        "items": {
+                                            "description": "This object contains a url to a media file.",
+                                            "type": "object",
+                                            "properties": {
+                                                "mimetype": {
+                                                    "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                    "type": "string"
+                                                },
+                                                "url": {
+                                                    "description": "The URL of the file",
+                                                    "type": "string",
+                                                    "format": "uri"
+                                                },
+                                                "signature": {
+                                                    "description": "The digital signature of the file signed by the sender",
+                                                    "type": "string"
+                                                },
+                                                "dsa": {
+                                                    "description": "The signing algorithm used by the sender",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "images": {
+                                        "type": "array",
+                                        "items": {
+                                            "description": "Describes an image",
+                                            "type": "object",
+                                            "properties": {
+                                                "url": {
+                                                    "description": "URL to the image. This can be a data url or an remote url",
+                                                    "type": "string",
+                                                    "format": "uri"
+                                                },
+                                                "size_type": {
+                                                    "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "xs",
+                                                        "sm",
+                                                        "md",
+                                                        "lg",
+                                                        "xl",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                "width": {
+                                                    "description": "Width of the image in pixels",
+                                                    "type": "string"
+                                                },
+                                                "height": {
+                                                    "description": "Height of the image in pixels",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "issuer": {
+                                "type": "object",
+                                "description": "Entity that issued the credential",
+                                "properties": {
+                                    "description": {
+                                        "description": "Physical description of something.",
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "code": {
+                                                "type": "string"
+                                            },
+                                            "short_desc": {
+                                                "type": "string"
+                                            },
+                                            "long_desc": {
+                                                "type": "string"
+                                            },
+                                            "additional_desc": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "url": {
+                                                        "type": "string"
+                                                    },
+                                                    "content_type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "text/plain",
+                                                            "text/html",
+                                                            "application/json"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "media": {
+                                                "type": "array",
+                                                "items": {
+                                                    "description": "This object contains a url to a media file.",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "mimetype": {
+                                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                            "type": "string"
+                                                        },
+                                                        "url": {
+                                                            "description": "The URL of the file",
+                                                            "type": "string",
+                                                            "format": "uri"
+                                                        },
+                                                        "signature": {
+                                                            "description": "The digital signature of the file signed by the sender",
+                                                            "type": "string"
+                                                        },
+                                                        "dsa": {
+                                                            "description": "The signing algorithm used by the sender",
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "images": {
+                                                "type": "array",
+                                                "items": {
+                                                    "description": "Describes an image",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "url": {
+                                                            "description": "URL to the image. This can be a data url or an remote url",
+                                                            "type": "string",
+                                                            "format": "uri"
+                                                        },
+                                                        "size_type": {
+                                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "xs",
+                                                                "sm",
+                                                                "md",
+                                                                "lg",
+                                                                "xl",
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "width": {
+                                                            "description": "Width of the image in pixels",
+                                                            "type": "string"
+                                                        },
+                                                        "height": {
+                                                            "description": "Height of the image in pixels",
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "address": {
+                                        "description": "Describes a postal address.",
+                                        "type": "string"
+                                    },
+                                    "state": {
+                                        "description": "A bounded geopolitical region of governance inside a country.",
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "Name of the state"
+                                            },
+                                            "code": {
+                                                "type": "string",
+                                                "description": "State code as per country or international standards"
+                                            }
+                                        }
+                                    },
+                                    "city": {
+                                        "description": "Describes a city",
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the city",
+                                                "type": "string"
+                                            },
+                                            "code": {
+                                                "description": "City code",
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "contact": {
+                                        "description": "Describes the contact information of an entity",
+                                        "type": "object",
+                                        "properties": {
+                                            "phone": {
+                                                "type": "string"
+                                            },
+                                            "email": {
+                                                "type": "string"
+                                            },
+                                            "jcard": {
+                                                "type": "object",
+                                                "description": "A Jcard object as per draft-ietf-jcardcal-jcard-03 specification"
+                                            }
+                                        }
+                                    },
+                                    "registration_number": {
+                                        "type": "string",
+                                        "description": "The registration number of the organization, if applicable."
+                                    },
+                                    "website": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "The official website of the issuing organization."
+                                    }
+                                }
+                            },
+                            "issueDate": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "The date when the credential was issued."
+                            },
+                            "validFrom": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "The expiration date of the credential, if applicable."
+                            },
+                            "validUntil": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "The expiration date of the credential, if applicable."
+                            },
+                            "credentialSubject": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "string"
+                                        },
+                                        "description": {
+                                            "description": "Physical description of something.",
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "code": {
+                                                    "type": "string"
+                                                },
+                                                "short_desc": {
+                                                    "type": "string"
+                                                },
+                                                "long_desc": {
+                                                    "type": "string"
+                                                },
+                                                "additional_desc": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "url": {
+                                                            "type": "string"
+                                                        },
+                                                        "content_type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text/plain",
+                                                                "text/html",
+                                                                "application/json"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "media": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "description": "This object contains a url to a media file.",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "mimetype": {
+                                                                "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                                "type": "string"
+                                                            },
+                                                            "url": {
+                                                                "description": "The URL of the file",
+                                                                "type": "string",
+                                                                "format": "uri"
+                                                            },
+                                                            "signature": {
+                                                                "description": "The digital signature of the file signed by the sender",
+                                                                "type": "string"
+                                                            },
+                                                            "dsa": {
+                                                                "description": "The signing algorithm used by the sender",
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "images": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "description": "Describes an image",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "url": {
+                                                                "description": "URL to the image. This can be a data url or an remote url",
+                                                                "type": "string",
+                                                                "format": "uri"
+                                                            },
+                                                            "size_type": {
+                                                                "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "xs",
+                                                                    "sm",
+                                                                    "md",
+                                                                    "lg",
+                                                                    "xl",
+                                                                    "custom"
+                                                                ]
+                                                            },
+                                                            "width": {
+                                                                "description": "Width of the image in pixels",
+                                                                "type": "string"
+                                                            },
+                                                            "height": {
+                                                                "description": "Height of the image in pixels",
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "tags": {
+                                            "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
+                                            "type": "object",
+                                            "properties": {
+                                                "display": {
+                                                    "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
+                                                    "type": "boolean",
+                                                    "default": true
+                                                },
+                                                "descriptor": {
+                                                    "description": "Description of the TagGroup, can be used to store detailed information.",
+                                                    "allOf": [
+                                                        {
+                                                            "description": "Physical description of something.",
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "code": {
+                                                                    "type": "string"
+                                                                },
+                                                                "short_desc": {
+                                                                    "type": "string"
+                                                                },
+                                                                "long_desc": {
+                                                                    "type": "string"
+                                                                },
+                                                                "additional_desc": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "url": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "content_type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text/plain",
+                                                                                "text/html",
+                                                                                "application/json"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "media": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "description": "This object contains a url to a media file.",
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "mimetype": {
+                                                                                "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "url": {
+                                                                                "description": "The URL of the file",
+                                                                                "type": "string",
+                                                                                "format": "uri"
+                                                                            },
+                                                                            "signature": {
+                                                                                "description": "The digital signature of the file signed by the sender",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "dsa": {
+                                                                                "description": "The signing algorithm used by the sender",
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "images": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "description": "Describes an image",
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "url": {
+                                                                                "description": "URL to the image. This can be a data url or an remote url",
+                                                                                "type": "string",
+                                                                                "format": "uri"
+                                                                            },
+                                                                            "size_type": {
+                                                                                "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "xs",
+                                                                                    "sm",
+                                                                                    "md",
+                                                                                    "lg",
+                                                                                    "xl",
+                                                                                    "custom"
+                                                                                ]
+                                                                            },
+                                                                            "width": {
+                                                                                "description": "Width of the image in pixels",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "height": {
+                                                                                "description": "Height of the image in pixels",
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "list": {
+                                                    "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "descriptor": {
+                                                                "description": "Description of the Tag, can be used to store detailed information.",
+                                                                "allOf": [
+                                                                    {
+                                                                        "description": "Physical description of something.",
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "code": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "short_desc": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "long_desc": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "additional_desc": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "content_type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text/plain",
+                                                                                            "text/html",
+                                                                                            "application/json"
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "media": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "description": "This object contains a url to a media file.",
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "mimetype": {
+                                                                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "url": {
+                                                                                            "description": "The URL of the file",
+                                                                                            "type": "string",
+                                                                                            "format": "uri"
+                                                                                        },
+                                                                                        "signature": {
+                                                                                            "description": "The digital signature of the file signed by the sender",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "dsa": {
+                                                                                            "description": "The signing algorithm used by the sender",
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "images": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "description": "Describes an image",
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "url": {
+                                                                                            "description": "URL to the image. This can be a data url or an remote url",
+                                                                                            "type": "string",
+                                                                                            "format": "uri"
+                                                                                        },
+                                                                                        "size_type": {
+                                                                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "xs",
+                                                                                                "sm",
+                                                                                                "md",
+                                                                                                "lg",
+                                                                                                "xl",
+                                                                                                "custom"
+                                                                                            ]
+                                                                                        },
+                                                                                        "width": {
+                                                                                            "description": "Width of the image in pixels",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "height": {
+                                                                                            "description": "Height of the image in pixels",
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "value": {
+                                                                "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
+                                                                "type": "string"
+                                                            },
+                                                            "display": {
+                                                                "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "credentialSchema": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "proof": {
+                                "type": "object",
+                                "description": "Cryptographic proof of the credential's authenticity",
+                                "properties": {
+                                    "created": {
+                                        "type": "string",
+                                        "format": "date-time",
+                                        "description": "Timestamp of when the proof was generated"
+                                    },
+                                    "proofPurpose": {
+                                        "type": "string",
+                                        "description": "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "description": "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
+                                    },
+                                    "verificationMethod": {
+                                        "type": "string",
+                                        "description": "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
+                                    },
+                                    "proofValue": {
+                                        "type": "string",
+                                        "description": "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
+                                    }
+                                }
+                            },
+                            "termsOfUse": {
+                                "type": "array",
+                                "items": {
+                                    "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
+                                    "type": "object",
+                                    "properties": {
+                                        "display": {
+                                            "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
+                                            "type": "boolean",
+                                            "default": true
+                                        },
+                                        "descriptor": {
+                                            "description": "Description of the TagGroup, can be used to store detailed information.",
+                                            "allOf": [
+                                                {
+                                                    "description": "Physical description of something.",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "code": {
+                                                            "type": "string"
+                                                        },
+                                                        "short_desc": {
+                                                            "type": "string"
+                                                        },
+                                                        "long_desc": {
+                                                            "type": "string"
+                                                        },
+                                                        "additional_desc": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "url": {
+                                                                    "type": "string"
+                                                                },
+                                                                "content_type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "text/plain",
+                                                                        "text/html",
+                                                                        "application/json"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "media": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "description": "This object contains a url to a media file.",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "mimetype": {
+                                                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "url": {
+                                                                        "description": "The URL of the file",
+                                                                        "type": "string",
+                                                                        "format": "uri"
+                                                                    },
+                                                                    "signature": {
+                                                                        "description": "The digital signature of the file signed by the sender",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "dsa": {
+                                                                        "description": "The signing algorithm used by the sender",
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "images": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "description": "Describes an image",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "url": {
+                                                                        "description": "URL to the image. This can be a data url or an remote url",
+                                                                        "type": "string",
+                                                                        "format": "uri"
+                                                                    },
+                                                                    "size_type": {
+                                                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "xs",
+                                                                            "sm",
+                                                                            "md",
+                                                                            "lg",
+                                                                            "xl",
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "width": {
+                                                                        "description": "Width of the image in pixels",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "height": {
+                                                                        "description": "Height of the image in pixels",
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "list": {
+                                            "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
+                                            "type": "array",
+                                            "items": {
+                                                "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
+                                                "type": "object",
+                                                "properties": {
+                                                    "descriptor": {
+                                                        "description": "Description of the Tag, can be used to store detailed information.",
+                                                        "allOf": [
+                                                            {
+                                                                "description": "Physical description of something.",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "code": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "short_desc": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "long_desc": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "additional_desc": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "url": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "content_type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text/plain",
+                                                                                    "text/html",
+                                                                                    "application/json"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "media": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "description": "This object contains a url to a media file.",
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "mimetype": {
+                                                                                    "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "url": {
+                                                                                    "description": "The URL of the file",
+                                                                                    "type": "string",
+                                                                                    "format": "uri"
+                                                                                },
+                                                                                "signature": {
+                                                                                    "description": "The digital signature of the file signed by the sender",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "dsa": {
+                                                                                    "description": "The signing algorithm used by the sender",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "images": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "description": "Describes an image",
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "description": "URL to the image. This can be a data url or an remote url",
+                                                                                    "type": "string",
+                                                                                    "format": "uri"
+                                                                                },
+                                                                                "size_type": {
+                                                                                    "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "xs",
+                                                                                        "sm",
+                                                                                        "md",
+                                                                                        "lg",
+                                                                                        "xl",
+                                                                                        "custom"
+                                                                                    ]
+                                                                                },
+                                                                                "width": {
+                                                                                    "description": "Width of the image in pixels",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "height": {
+                                                                                    "description": "Height of the image in pixels",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "value": {
+                                                        "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
+                                                        "type": "string"
+                                                    },
+                                                    "display": {
+                                                        "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "credentialStatus": {
+                                "type": "array",
+                                "items": {
+                                    "description": "Physical description of something.",
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "short_desc": {
+                                            "type": "string"
+                                        },
+                                        "long_desc": {
+                                            "type": "string"
+                                        },
+                                        "additional_desc": {
+                                            "type": "object",
+                                            "properties": {
+                                                "url": {
+                                                    "type": "string"
+                                                },
+                                                "content_type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "text/plain",
+                                                        "text/html",
+                                                        "application/json"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "media": {
+                                            "type": "array",
+                                            "items": {
+                                                "description": "This object contains a url to a media file.",
+                                                "type": "object",
+                                                "properties": {
+                                                    "mimetype": {
+                                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                        "type": "string"
+                                                    },
+                                                    "url": {
+                                                        "description": "The URL of the file",
+                                                        "type": "string",
+                                                        "format": "uri"
+                                                    },
+                                                    "signature": {
+                                                        "description": "The digital signature of the file signed by the sender",
+                                                        "type": "string"
+                                                    },
+                                                    "dsa": {
+                                                        "description": "The signing algorithm used by the sender",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "images": {
+                                            "type": "array",
+                                            "items": {
+                                                "description": "Describes an image",
+                                                "type": "object",
+                                                "properties": {
+                                                    "url": {
+                                                        "description": "URL to the image. This can be a data url or an remote url",
+                                                        "type": "string",
+                                                        "format": "uri"
+                                                    },
+                                                    "size_type": {
+                                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "xs",
+                                                            "sm",
+                                                            "md",
+                                                            "lg",
+                                                            "xl",
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "width": {
+                                                        "description": "Width of the image in pixels",
+                                                        "type": "string"
+                                                    },
+                                                    "height": {
+                                                        "description": "Height of the image in pixels",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "evidence": {
+                                "type": "array",
+                                "items": {
+                                    "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
+                                    "type": "object",
+                                    "properties": {
+                                        "display": {
+                                            "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
+                                            "type": "boolean",
+                                            "default": true
+                                        },
+                                        "descriptor": {
+                                            "description": "Description of the TagGroup, can be used to store detailed information.",
+                                            "allOf": [
+                                                {
+                                                    "description": "Physical description of something.",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "code": {
+                                                            "type": "string"
+                                                        },
+                                                        "short_desc": {
+                                                            "type": "string"
+                                                        },
+                                                        "long_desc": {
+                                                            "type": "string"
+                                                        },
+                                                        "additional_desc": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "url": {
+                                                                    "type": "string"
+                                                                },
+                                                                "content_type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "text/plain",
+                                                                        "text/html",
+                                                                        "application/json"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "media": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "description": "This object contains a url to a media file.",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "mimetype": {
+                                                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "url": {
+                                                                        "description": "The URL of the file",
+                                                                        "type": "string",
+                                                                        "format": "uri"
+                                                                    },
+                                                                    "signature": {
+                                                                        "description": "The digital signature of the file signed by the sender",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "dsa": {
+                                                                        "description": "The signing algorithm used by the sender",
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "images": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "description": "Describes an image",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "url": {
+                                                                        "description": "URL to the image. This can be a data url or an remote url",
+                                                                        "type": "string",
+                                                                        "format": "uri"
+                                                                    },
+                                                                    "size_type": {
+                                                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "xs",
+                                                                            "sm",
+                                                                            "md",
+                                                                            "lg",
+                                                                            "xl",
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "width": {
+                                                                        "description": "Width of the image in pixels",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "height": {
+                                                                        "description": "Height of the image in pixels",
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "list": {
+                                            "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
+                                            "type": "array",
+                                            "items": {
+                                                "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
+                                                "type": "object",
+                                                "properties": {
+                                                    "descriptor": {
+                                                        "description": "Description of the Tag, can be used to store detailed information.",
+                                                        "allOf": [
+                                                            {
+                                                                "description": "Physical description of something.",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "code": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "short_desc": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "long_desc": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "additional_desc": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "url": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "content_type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text/plain",
+                                                                                    "text/html",
+                                                                                    "application/json"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "media": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "description": "This object contains a url to a media file.",
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "mimetype": {
+                                                                                    "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "url": {
+                                                                                    "description": "The URL of the file",
+                                                                                    "type": "string",
+                                                                                    "format": "uri"
+                                                                                },
+                                                                                "signature": {
+                                                                                    "description": "The digital signature of the file signed by the sender",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "dsa": {
+                                                                                    "description": "The signing algorithm used by the sender",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "images": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "description": "Describes an image",
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "description": "URL to the image. This can be a data url or an remote url",
+                                                                                    "type": "string",
+                                                                                    "format": "uri"
+                                                                                },
+                                                                                "size_type": {
+                                                                                    "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "xs",
+                                                                                        "sm",
+                                                                                        "md",
+                                                                                        "lg",
+                                                                                        "xl",
+                                                                                        "custom"
+                                                                                    ]
+                                                                                },
+                                                                                "width": {
+                                                                                    "description": "Width of the image in pixels",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "height": {
+                                                                                    "description": "Height of the image in pixels",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "value": {
+                                                        "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
+                                                        "type": "string"
+                                                    },
+                                                    "display": {
+                                                        "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "layer2Config": {
+            "type": "string",
+            "format": "url"
+        }
+    }
+}

--- a/api/about-endpoint/becknVerifiableCredential.json
+++ b/api/about-endpoint/becknVerifiableCredential.json
@@ -1,0 +1,1480 @@
+{
+    "$id": "becknVerifiableCredential",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Describes a credential of an entity - Person, Organization, Item, Payment etc",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "type": {
+            "type": "string"
+        },
+        "description": {
+            "description": "Physical description of something.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "code": {
+                    "type": "string"
+                },
+                "short_desc": {
+                    "type": "string"
+                },
+                "long_desc": {
+                    "type": "string"
+                },
+                "additional_desc": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string"
+                        },
+                        "content_type": {
+                            "type": "string",
+                            "enum": [
+                                "text/plain",
+                                "text/html",
+                                "application/json"
+                            ]
+                        }
+                    }
+                },
+                "media": {
+                    "type": "array",
+                    "items": {
+                        "description": "This object contains a url to a media file.",
+                        "type": "object",
+                        "properties": {
+                            "mimetype": {
+                                "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                "type": "string"
+                            },
+                            "url": {
+                                "description": "The URL of the file",
+                                "type": "string",
+                                "format": "uri"
+                            },
+                            "signature": {
+                                "description": "The digital signature of the file signed by the sender",
+                                "type": "string"
+                            },
+                            "dsa": {
+                                "description": "The signing algorithm used by the sender",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "description": "Describes an image",
+                        "type": "object",
+                        "properties": {
+                            "url": {
+                                "description": "URL to the image. This can be a data url or an remote url",
+                                "type": "string",
+                                "format": "uri"
+                            },
+                            "size_type": {
+                                "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                "type": "string",
+                                "enum": [
+                                    "xs",
+                                    "sm",
+                                    "md",
+                                    "lg",
+                                    "xl",
+                                    "custom"
+                                ]
+                            },
+                            "width": {
+                                "description": "Width of the image in pixels",
+                                "type": "string"
+                            },
+                            "height": {
+                                "description": "Height of the image in pixels",
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "docs": {
+            "description": "The Documents associated with the credential.",
+            "type": "array",
+            "items": {
+                "description": "Describes a document which can be sent as a url",
+                "type": "object",
+                "properties": {
+                    "descriptor": {
+                        "description": "Physical description of something.",
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "code": {
+                                "type": "string"
+                            },
+                            "short_desc": {
+                                "type": "string"
+                            },
+                            "long_desc": {
+                                "type": "string"
+                            },
+                            "additional_desc": {
+                                "type": "object",
+                                "properties": {
+                                    "url": {
+                                        "type": "string"
+                                    },
+                                    "content_type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "text/plain",
+                                            "text/html",
+                                            "application/json"
+                                        ]
+                                    }
+                                }
+                            },
+                            "media": {
+                                "type": "array",
+                                "items": {
+                                    "description": "This object contains a url to a media file.",
+                                    "type": "object",
+                                    "properties": {
+                                        "mimetype": {
+                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                            "type": "string"
+                                        },
+                                        "url": {
+                                            "description": "The URL of the file",
+                                            "type": "string",
+                                            "format": "uri"
+                                        },
+                                        "signature": {
+                                            "description": "The digital signature of the file signed by the sender",
+                                            "type": "string"
+                                        },
+                                        "dsa": {
+                                            "description": "The signing algorithm used by the sender",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "images": {
+                                "type": "array",
+                                "items": {
+                                    "description": "Describes an image",
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {
+                                            "description": "URL to the image. This can be a data url or an remote url",
+                                            "type": "string",
+                                            "format": "uri"
+                                        },
+                                        "size_type": {
+                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                            "type": "string",
+                                            "enum": [
+                                                "xs",
+                                                "sm",
+                                                "md",
+                                                "lg",
+                                                "xl",
+                                                "custom"
+                                            ]
+                                        },
+                                        "width": {
+                                            "description": "Width of the image in pixels",
+                                            "type": "string"
+                                        },
+                                        "height": {
+                                            "description": "Height of the image in pixels",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "url": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "label": {
+                        "type": "string"
+                    },
+                    "mime_type": {
+                        "description": "Describes the contents of the uri field. If the value is text/html, it is recommended for the BAP to render the contents inside a webview. This generally does not render a good user experience on the BAP, hence the payment page developers are recommended to develop their payment pages in a mobile-friendly manner.",
+                        "type": "string",
+                        "enum": [
+                            "application/pdf",
+                            "text/plain",
+                            "image/jpeg",
+                            "video/mp4",
+                            "audio/wav",
+                            "application/zip"
+                        ]
+                    }
+                }
+            }
+        },
+        "media": {
+            "description": "The Media associated with the credential.",
+            "type": "array",
+            "items": {
+                "description": "This object contains a url to a media file.",
+                "type": "object",
+                "properties": {
+                    "mimetype": {
+                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "The URL of the file",
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "signature": {
+                        "description": "The digital signature of the file signed by the sender",
+                        "type": "string"
+                    },
+                    "dsa": {
+                        "description": "The signing algorithm used by the sender",
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "url": {
+            "description": "URL of the credential",
+            "type": "string",
+            "format": "uri"
+        },
+        "verifiableCredential": {
+            "description": "Describes a Verifiable Credential",
+            "type": "object",
+            "properties": {
+                "context": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "id": {
+                    "description": "A unique identifier for the credential (e.g., UUID or URI).",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Types of the credential.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "description": {
+                    "description": "Physical description of something.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "code": {
+                            "type": "string"
+                        },
+                        "short_desc": {
+                            "type": "string"
+                        },
+                        "long_desc": {
+                            "type": "string"
+                        },
+                        "additional_desc": {
+                            "type": "object",
+                            "properties": {
+                                "url": {
+                                    "type": "string"
+                                },
+                                "content_type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "text/plain",
+                                        "text/html",
+                                        "application/json"
+                                    ]
+                                }
+                            }
+                        },
+                        "media": {
+                            "type": "array",
+                            "items": {
+                                "description": "This object contains a url to a media file.",
+                                "type": "object",
+                                "properties": {
+                                    "mimetype": {
+                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                        "type": "string"
+                                    },
+                                    "url": {
+                                        "description": "The URL of the file",
+                                        "type": "string",
+                                        "format": "uri"
+                                    },
+                                    "signature": {
+                                        "description": "The digital signature of the file signed by the sender",
+                                        "type": "string"
+                                    },
+                                    "dsa": {
+                                        "description": "The signing algorithm used by the sender",
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "images": {
+                            "type": "array",
+                            "items": {
+                                "description": "Describes an image",
+                                "type": "object",
+                                "properties": {
+                                    "url": {
+                                        "description": "URL to the image. This can be a data url or an remote url",
+                                        "type": "string",
+                                        "format": "uri"
+                                    },
+                                    "size_type": {
+                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                        "type": "string",
+                                        "enum": [
+                                            "xs",
+                                            "sm",
+                                            "md",
+                                            "lg",
+                                            "xl",
+                                            "custom"
+                                        ]
+                                    },
+                                    "width": {
+                                        "description": "Width of the image in pixels",
+                                        "type": "string"
+                                    },
+                                    "height": {
+                                        "description": "Height of the image in pixels",
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "issuer": {
+                    "type": "object",
+                    "description": "Entity that issued the credential",
+                    "properties": {
+                        "description": {
+                            "description": "Physical description of something.",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "code": {
+                                    "type": "string"
+                                },
+                                "short_desc": {
+                                    "type": "string"
+                                },
+                                "long_desc": {
+                                    "type": "string"
+                                },
+                                "additional_desc": {
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {
+                                            "type": "string"
+                                        },
+                                        "content_type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "text/plain",
+                                                "text/html",
+                                                "application/json"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "media": {
+                                    "type": "array",
+                                    "items": {
+                                        "description": "This object contains a url to a media file.",
+                                        "type": "object",
+                                        "properties": {
+                                            "mimetype": {
+                                                "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                "type": "string"
+                                            },
+                                            "url": {
+                                                "description": "The URL of the file",
+                                                "type": "string",
+                                                "format": "uri"
+                                            },
+                                            "signature": {
+                                                "description": "The digital signature of the file signed by the sender",
+                                                "type": "string"
+                                            },
+                                            "dsa": {
+                                                "description": "The signing algorithm used by the sender",
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "images": {
+                                    "type": "array",
+                                    "items": {
+                                        "description": "Describes an image",
+                                        "type": "object",
+                                        "properties": {
+                                            "url": {
+                                                "description": "URL to the image. This can be a data url or an remote url",
+                                                "type": "string",
+                                                "format": "uri"
+                                            },
+                                            "size_type": {
+                                                "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                "type": "string",
+                                                "enum": [
+                                                    "xs",
+                                                    "sm",
+                                                    "md",
+                                                    "lg",
+                                                    "xl",
+                                                    "custom"
+                                                ]
+                                            },
+                                            "width": {
+                                                "description": "Width of the image in pixels",
+                                                "type": "string"
+                                            },
+                                            "height": {
+                                                "description": "Height of the image in pixels",
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "address": {
+                            "description": "Describes a postal address.",
+                            "type": "string"
+                        },
+                        "state": {
+                            "description": "A bounded geopolitical region of governance inside a country.",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the state"
+                                },
+                                "code": {
+                                    "type": "string",
+                                    "description": "State code as per country or international standards"
+                                }
+                            }
+                        },
+                        "city": {
+                            "description": "Describes a city",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "description": "Name of the city",
+                                    "type": "string"
+                                },
+                                "code": {
+                                    "description": "City code",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "contact": {
+                            "description": "Describes the contact information of an entity",
+                            "type": "object",
+                            "properties": {
+                                "phone": {
+                                    "type": "string"
+                                },
+                                "email": {
+                                    "type": "string"
+                                },
+                                "jcard": {
+                                    "type": "object",
+                                    "description": "A Jcard object as per draft-ietf-jcardcal-jcard-03 specification"
+                                }
+                            }
+                        },
+                        "registration_number": {
+                            "type": "string",
+                            "description": "The registration number of the organization, if applicable."
+                        },
+                        "website": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The official website of the issuing organization."
+                        }
+                    }
+                },
+                "issueDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "The date when the credential was issued."
+                },
+                "validFrom": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "The expiration date of the credential, if applicable."
+                },
+                "validUntil": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "The expiration date of the credential, if applicable."
+                },
+                "credentialSubject": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "description": "Physical description of something.",
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    },
+                                    "short_desc": {
+                                        "type": "string"
+                                    },
+                                    "long_desc": {
+                                        "type": "string"
+                                    },
+                                    "additional_desc": {
+                                        "type": "object",
+                                        "properties": {
+                                            "url": {
+                                                "type": "string"
+                                            },
+                                            "content_type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text/plain",
+                                                    "text/html",
+                                                    "application/json"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "media": {
+                                        "type": "array",
+                                        "items": {
+                                            "description": "This object contains a url to a media file.",
+                                            "type": "object",
+                                            "properties": {
+                                                "mimetype": {
+                                                    "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                    "type": "string"
+                                                },
+                                                "url": {
+                                                    "description": "The URL of the file",
+                                                    "type": "string",
+                                                    "format": "uri"
+                                                },
+                                                "signature": {
+                                                    "description": "The digital signature of the file signed by the sender",
+                                                    "type": "string"
+                                                },
+                                                "dsa": {
+                                                    "description": "The signing algorithm used by the sender",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "images": {
+                                        "type": "array",
+                                        "items": {
+                                            "description": "Describes an image",
+                                            "type": "object",
+                                            "properties": {
+                                                "url": {
+                                                    "description": "URL to the image. This can be a data url or an remote url",
+                                                    "type": "string",
+                                                    "format": "uri"
+                                                },
+                                                "size_type": {
+                                                    "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "xs",
+                                                        "sm",
+                                                        "md",
+                                                        "lg",
+                                                        "xl",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                "width": {
+                                                    "description": "Width of the image in pixels",
+                                                    "type": "string"
+                                                },
+                                                "height": {
+                                                    "description": "Height of the image in pixels",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "tags": {
+                                "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
+                                "type": "object",
+                                "properties": {
+                                    "display": {
+                                        "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "descriptor": {
+                                        "description": "Description of the TagGroup, can be used to store detailed information.",
+                                        "allOf": [
+                                            {
+                                                "description": "Physical description of something.",
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "code": {
+                                                        "type": "string"
+                                                    },
+                                                    "short_desc": {
+                                                        "type": "string"
+                                                    },
+                                                    "long_desc": {
+                                                        "type": "string"
+                                                    },
+                                                    "additional_desc": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "url": {
+                                                                "type": "string"
+                                                            },
+                                                            "content_type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "text/plain",
+                                                                    "text/html",
+                                                                    "application/json"
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    "media": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "description": "This object contains a url to a media file.",
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mimetype": {
+                                                                    "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                                    "type": "string"
+                                                                },
+                                                                "url": {
+                                                                    "description": "The URL of the file",
+                                                                    "type": "string",
+                                                                    "format": "uri"
+                                                                },
+                                                                "signature": {
+                                                                    "description": "The digital signature of the file signed by the sender",
+                                                                    "type": "string"
+                                                                },
+                                                                "dsa": {
+                                                                    "description": "The signing algorithm used by the sender",
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "images": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "description": "Describes an image",
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "url": {
+                                                                    "description": "URL to the image. This can be a data url or an remote url",
+                                                                    "type": "string",
+                                                                    "format": "uri"
+                                                                },
+                                                                "size_type": {
+                                                                    "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "xs",
+                                                                        "sm",
+                                                                        "md",
+                                                                        "lg",
+                                                                        "xl",
+                                                                        "custom"
+                                                                    ]
+                                                                },
+                                                                "width": {
+                                                                    "description": "Width of the image in pixels",
+                                                                    "type": "string"
+                                                                },
+                                                                "height": {
+                                                                    "description": "Height of the image in pixels",
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "list": {
+                                        "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
+                                        "type": "array",
+                                        "items": {
+                                            "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
+                                            "type": "object",
+                                            "properties": {
+                                                "descriptor": {
+                                                    "description": "Description of the Tag, can be used to store detailed information.",
+                                                    "allOf": [
+                                                        {
+                                                            "description": "Physical description of something.",
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "code": {
+                                                                    "type": "string"
+                                                                },
+                                                                "short_desc": {
+                                                                    "type": "string"
+                                                                },
+                                                                "long_desc": {
+                                                                    "type": "string"
+                                                                },
+                                                                "additional_desc": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "url": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "content_type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text/plain",
+                                                                                "text/html",
+                                                                                "application/json"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "media": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "description": "This object contains a url to a media file.",
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "mimetype": {
+                                                                                "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "url": {
+                                                                                "description": "The URL of the file",
+                                                                                "type": "string",
+                                                                                "format": "uri"
+                                                                            },
+                                                                            "signature": {
+                                                                                "description": "The digital signature of the file signed by the sender",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "dsa": {
+                                                                                "description": "The signing algorithm used by the sender",
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "images": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "description": "Describes an image",
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "url": {
+                                                                                "description": "URL to the image. This can be a data url or an remote url",
+                                                                                "type": "string",
+                                                                                "format": "uri"
+                                                                            },
+                                                                            "size_type": {
+                                                                                "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "xs",
+                                                                                    "sm",
+                                                                                    "md",
+                                                                                    "lg",
+                                                                                    "xl",
+                                                                                    "custom"
+                                                                                ]
+                                                                            },
+                                                                            "width": {
+                                                                                "description": "Width of the image in pixels",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "height": {
+                                                                                "description": "Height of the image in pixels",
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "value": {
+                                                    "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
+                                                    "type": "string"
+                                                },
+                                                "display": {
+                                                    "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "credentialSchema": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "proof": {
+                    "type": "object",
+                    "description": "Cryptographic proof of the credential's authenticity",
+                    "properties": {
+                        "created": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Timestamp of when the proof was generated"
+                        },
+                        "proofPurpose": {
+                            "type": "string",
+                            "description": "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
+                        },
+                        "verificationMethod": {
+                            "type": "string",
+                            "description": "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
+                        },
+                        "proofValue": {
+                            "type": "string",
+                            "description": "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
+                        }
+                    }
+                },
+                "termsOfUse": {
+                    "type": "array",
+                    "items": {
+                        "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
+                        "type": "object",
+                        "properties": {
+                            "display": {
+                                "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
+                                "type": "boolean",
+                                "default": true
+                            },
+                            "descriptor": {
+                                "description": "Description of the TagGroup, can be used to store detailed information.",
+                                "allOf": [
+                                    {
+                                        "description": "Physical description of something.",
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "code": {
+                                                "type": "string"
+                                            },
+                                            "short_desc": {
+                                                "type": "string"
+                                            },
+                                            "long_desc": {
+                                                "type": "string"
+                                            },
+                                            "additional_desc": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "url": {
+                                                        "type": "string"
+                                                    },
+                                                    "content_type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "text/plain",
+                                                            "text/html",
+                                                            "application/json"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "media": {
+                                                "type": "array",
+                                                "items": {
+                                                    "description": "This object contains a url to a media file.",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "mimetype": {
+                                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                            "type": "string"
+                                                        },
+                                                        "url": {
+                                                            "description": "The URL of the file",
+                                                            "type": "string",
+                                                            "format": "uri"
+                                                        },
+                                                        "signature": {
+                                                            "description": "The digital signature of the file signed by the sender",
+                                                            "type": "string"
+                                                        },
+                                                        "dsa": {
+                                                            "description": "The signing algorithm used by the sender",
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "images": {
+                                                "type": "array",
+                                                "items": {
+                                                    "description": "Describes an image",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "url": {
+                                                            "description": "URL to the image. This can be a data url or an remote url",
+                                                            "type": "string",
+                                                            "format": "uri"
+                                                        },
+                                                        "size_type": {
+                                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "xs",
+                                                                "sm",
+                                                                "md",
+                                                                "lg",
+                                                                "xl",
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "width": {
+                                                            "description": "Width of the image in pixels",
+                                                            "type": "string"
+                                                        },
+                                                        "height": {
+                                                            "description": "Height of the image in pixels",
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "list": {
+                                "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
+                                "type": "array",
+                                "items": {
+                                    "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
+                                    "type": "object",
+                                    "properties": {
+                                        "descriptor": {
+                                            "description": "Description of the Tag, can be used to store detailed information.",
+                                            "allOf": [
+                                                {
+                                                    "description": "Physical description of something.",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "code": {
+                                                            "type": "string"
+                                                        },
+                                                        "short_desc": {
+                                                            "type": "string"
+                                                        },
+                                                        "long_desc": {
+                                                            "type": "string"
+                                                        },
+                                                        "additional_desc": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "url": {
+                                                                    "type": "string"
+                                                                },
+                                                                "content_type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "text/plain",
+                                                                        "text/html",
+                                                                        "application/json"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "media": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "description": "This object contains a url to a media file.",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "mimetype": {
+                                                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "url": {
+                                                                        "description": "The URL of the file",
+                                                                        "type": "string",
+                                                                        "format": "uri"
+                                                                    },
+                                                                    "signature": {
+                                                                        "description": "The digital signature of the file signed by the sender",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "dsa": {
+                                                                        "description": "The signing algorithm used by the sender",
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "images": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "description": "Describes an image",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "url": {
+                                                                        "description": "URL to the image. This can be a data url or an remote url",
+                                                                        "type": "string",
+                                                                        "format": "uri"
+                                                                    },
+                                                                    "size_type": {
+                                                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "xs",
+                                                                            "sm",
+                                                                            "md",
+                                                                            "lg",
+                                                                            "xl",
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "width": {
+                                                                        "description": "Width of the image in pixels",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "height": {
+                                                                        "description": "Height of the image in pixels",
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "value": {
+                                            "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
+                                            "type": "string"
+                                        },
+                                        "display": {
+                                            "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "credentialStatus": {
+                    "type": "array",
+                    "items": {
+                        "description": "Physical description of something.",
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "code": {
+                                "type": "string"
+                            },
+                            "short_desc": {
+                                "type": "string"
+                            },
+                            "long_desc": {
+                                "type": "string"
+                            },
+                            "additional_desc": {
+                                "type": "object",
+                                "properties": {
+                                    "url": {
+                                        "type": "string"
+                                    },
+                                    "content_type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "text/plain",
+                                            "text/html",
+                                            "application/json"
+                                        ]
+                                    }
+                                }
+                            },
+                            "media": {
+                                "type": "array",
+                                "items": {
+                                    "description": "This object contains a url to a media file.",
+                                    "type": "object",
+                                    "properties": {
+                                        "mimetype": {
+                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                            "type": "string"
+                                        },
+                                        "url": {
+                                            "description": "The URL of the file",
+                                            "type": "string",
+                                            "format": "uri"
+                                        },
+                                        "signature": {
+                                            "description": "The digital signature of the file signed by the sender",
+                                            "type": "string"
+                                        },
+                                        "dsa": {
+                                            "description": "The signing algorithm used by the sender",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "images": {
+                                "type": "array",
+                                "items": {
+                                    "description": "Describes an image",
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {
+                                            "description": "URL to the image. This can be a data url or an remote url",
+                                            "type": "string",
+                                            "format": "uri"
+                                        },
+                                        "size_type": {
+                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                            "type": "string",
+                                            "enum": [
+                                                "xs",
+                                                "sm",
+                                                "md",
+                                                "lg",
+                                                "xl",
+                                                "custom"
+                                            ]
+                                        },
+                                        "width": {
+                                            "description": "Width of the image in pixels",
+                                            "type": "string"
+                                        },
+                                        "height": {
+                                            "description": "Height of the image in pixels",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "evidence": {
+                    "type": "array",
+                    "items": {
+                        "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
+                        "type": "object",
+                        "properties": {
+                            "display": {
+                                "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
+                                "type": "boolean",
+                                "default": true
+                            },
+                            "descriptor": {
+                                "description": "Description of the TagGroup, can be used to store detailed information.",
+                                "allOf": [
+                                    {
+                                        "description": "Physical description of something.",
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "code": {
+                                                "type": "string"
+                                            },
+                                            "short_desc": {
+                                                "type": "string"
+                                            },
+                                            "long_desc": {
+                                                "type": "string"
+                                            },
+                                            "additional_desc": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "url": {
+                                                        "type": "string"
+                                                    },
+                                                    "content_type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "text/plain",
+                                                            "text/html",
+                                                            "application/json"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "media": {
+                                                "type": "array",
+                                                "items": {
+                                                    "description": "This object contains a url to a media file.",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "mimetype": {
+                                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                            "type": "string"
+                                                        },
+                                                        "url": {
+                                                            "description": "The URL of the file",
+                                                            "type": "string",
+                                                            "format": "uri"
+                                                        },
+                                                        "signature": {
+                                                            "description": "The digital signature of the file signed by the sender",
+                                                            "type": "string"
+                                                        },
+                                                        "dsa": {
+                                                            "description": "The signing algorithm used by the sender",
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "images": {
+                                                "type": "array",
+                                                "items": {
+                                                    "description": "Describes an image",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "url": {
+                                                            "description": "URL to the image. This can be a data url or an remote url",
+                                                            "type": "string",
+                                                            "format": "uri"
+                                                        },
+                                                        "size_type": {
+                                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "xs",
+                                                                "sm",
+                                                                "md",
+                                                                "lg",
+                                                                "xl",
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "width": {
+                                                            "description": "Width of the image in pixels",
+                                                            "type": "string"
+                                                        },
+                                                        "height": {
+                                                            "description": "Height of the image in pixels",
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "list": {
+                                "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
+                                "type": "array",
+                                "items": {
+                                    "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
+                                    "type": "object",
+                                    "properties": {
+                                        "descriptor": {
+                                            "description": "Description of the Tag, can be used to store detailed information.",
+                                            "allOf": [
+                                                {
+                                                    "description": "Physical description of something.",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "code": {
+                                                            "type": "string"
+                                                        },
+                                                        "short_desc": {
+                                                            "type": "string"
+                                                        },
+                                                        "long_desc": {
+                                                            "type": "string"
+                                                        },
+                                                        "additional_desc": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "url": {
+                                                                    "type": "string"
+                                                                },
+                                                                "content_type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "text/plain",
+                                                                        "text/html",
+                                                                        "application/json"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "media": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "description": "This object contains a url to a media file.",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "mimetype": {
+                                                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "url": {
+                                                                        "description": "The URL of the file",
+                                                                        "type": "string",
+                                                                        "format": "uri"
+                                                                    },
+                                                                    "signature": {
+                                                                        "description": "The digital signature of the file signed by the sender",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "dsa": {
+                                                                        "description": "The signing algorithm used by the sender",
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "images": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "description": "Describes an image",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "url": {
+                                                                        "description": "URL to the image. This can be a data url or an remote url",
+                                                                        "type": "string",
+                                                                        "format": "uri"
+                                                                    },
+                                                                    "size_type": {
+                                                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "xs",
+                                                                            "sm",
+                                                                            "md",
+                                                                            "lg",
+                                                                            "xl",
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "width": {
+                                                                        "description": "Width of the image in pixels",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "height": {
+                                                                        "description": "Height of the image in pixels",
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "value": {
+                                            "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
+                                            "type": "string"
+                                        },
+                                        "display": {
+                                            "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/api/about-endpoint/becknVerifiableCredential.json
+++ b/api/about-endpoint/becknVerifiableCredential.json
@@ -281,1198 +281,183 @@
                     }
                 },
                 "description": {
-                    "description": "Physical description of something.",
-                    "type": "object",
-                    "properties": {
-                        "name": {
+                    "anyOf": [
+                        {
                             "type": "string"
                         },
-                        "code": {
-                            "type": "string"
+                        {
+                            "type": "object"
                         },
-                        "short_desc": {
-                            "type": "string"
-                        },
-                        "long_desc": {
-                            "type": "string"
-                        },
-                        "additional_desc": {
-                            "type": "object",
-                            "properties": {
-                                "url": {
-                                    "type": "string"
-                                },
-                                "content_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "text/plain",
-                                        "text/html",
-                                        "application/json"
-                                    ]
-                                }
-                            }
-                        },
-                        "media": {
+                        {
                             "type": "array",
                             "items": {
-                                "description": "This object contains a url to a media file.",
-                                "type": "object",
-                                "properties": {
-                                    "mimetype": {
-                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                        "type": "string"
-                                    },
-                                    "url": {
-                                        "description": "The URL of the file",
-                                        "type": "string",
-                                        "format": "uri"
-                                    },
-                                    "signature": {
-                                        "description": "The digital signature of the file signed by the sender",
-                                        "type": "string"
-                                    },
-                                    "dsa": {
-                                        "description": "The signing algorithm used by the sender",
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "images": {
-                            "type": "array",
-                            "items": {
-                                "description": "Describes an image",
-                                "type": "object",
-                                "properties": {
-                                    "url": {
-                                        "description": "URL to the image. This can be a data url or an remote url",
-                                        "type": "string",
-                                        "format": "uri"
-                                    },
-                                    "size_type": {
-                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                        "type": "string",
-                                        "enum": [
-                                            "xs",
-                                            "sm",
-                                            "md",
-                                            "lg",
-                                            "xl",
-                                            "custom"
-                                        ]
-                                    },
-                                    "width": {
-                                        "description": "Width of the image in pixels",
-                                        "type": "string"
-                                    },
-                                    "height": {
-                                        "description": "Height of the image in pixels",
-                                        "type": "string"
-                                    }
-                                }
+                                "type": "object"
                             }
                         }
-                    }
+                    ]
                 },
                 "issuer": {
-                    "type": "object",
-                    "description": "Entity that issued the credential",
-                    "properties": {
-                        "description": {
-                            "description": "Physical description of something.",
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "code": {
-                                    "type": "string"
-                                },
-                                "short_desc": {
-                                    "type": "string"
-                                },
-                                "long_desc": {
-                                    "type": "string"
-                                },
-                                "additional_desc": {
-                                    "type": "object",
-                                    "properties": {
-                                        "url": {
-                                            "type": "string"
-                                        },
-                                        "content_type": {
-                                            "type": "string",
-                                            "enum": [
-                                                "text/plain",
-                                                "text/html",
-                                                "application/json"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "media": {
-                                    "type": "array",
-                                    "items": {
-                                        "description": "This object contains a url to a media file.",
-                                        "type": "object",
-                                        "properties": {
-                                            "mimetype": {
-                                                "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                "type": "string"
-                                            },
-                                            "url": {
-                                                "description": "The URL of the file",
-                                                "type": "string",
-                                                "format": "uri"
-                                            },
-                                            "signature": {
-                                                "description": "The digital signature of the file signed by the sender",
-                                                "type": "string"
-                                            },
-                                            "dsa": {
-                                                "description": "The signing algorithm used by the sender",
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "images": {
-                                    "type": "array",
-                                    "items": {
-                                        "description": "Describes an image",
-                                        "type": "object",
-                                        "properties": {
-                                            "url": {
-                                                "description": "URL to the image. This can be a data url or an remote url",
-                                                "type": "string",
-                                                "format": "uri"
-                                            },
-                                            "size_type": {
-                                                "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                "type": "string",
-                                                "enum": [
-                                                    "xs",
-                                                    "sm",
-                                                    "md",
-                                                    "lg",
-                                                    "xl",
-                                                    "custom"
-                                                ]
-                                            },
-                                            "width": {
-                                                "description": "Width of the image in pixels",
-                                                "type": "string"
-                                            },
-                                            "height": {
-                                                "description": "Height of the image in pixels",
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "address": {
-                            "description": "Describes a postal address.",
+                    "anyOf": [
+                        {
                             "type": "string"
                         },
-                        "state": {
-                            "description": "A bounded geopolitical region of governance inside a country.",
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string",
-                                    "description": "Name of the state"
-                                },
-                                "code": {
-                                    "type": "string",
-                                    "description": "State code as per country or international standards"
-                                }
-                            }
-                        },
-                        "city": {
-                            "description": "Describes a city",
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "description": "Name of the city",
-                                    "type": "string"
-                                },
-                                "code": {
-                                    "description": "City code",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "contact": {
-                            "description": "Describes the contact information of an entity",
-                            "type": "object",
-                            "properties": {
-                                "phone": {
-                                    "type": "string"
-                                },
-                                "email": {
-                                    "type": "string"
-                                },
-                                "jcard": {
-                                    "type": "object",
-                                    "description": "A Jcard object as per draft-ietf-jcardcal-jcard-03 specification"
-                                }
-                            }
-                        },
-                        "registration_number": {
-                            "type": "string",
-                            "description": "The registration number of the organization, if applicable."
-                        },
-                        "website": {
-                            "type": "string",
-                            "format": "uri",
-                            "description": "The official website of the issuing organization."
+                        {
+                            "type": "object"
                         }
-                    }
+                    ]
                 },
-                "issueDate": {
+                "issuanceDate": {
                     "type": "string",
-                    "format": "date-time",
                     "description": "The date when the credential was issued."
                 },
                 "validFrom": {
                     "type": "string",
-                    "format": "date-time",
                     "description": "The expiration date of the credential, if applicable."
                 },
                 "validUntil": {
                     "type": "string",
-                    "format": "date-time",
                     "description": "The expiration date of the credential, if applicable."
                 },
                 "credentialSubject": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "id": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
                                 "type": "string"
-                            },
-                            "description": {
-                                "description": "Physical description of something.",
-                                "type": "object",
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "code": {
-                                        "type": "string"
-                                    },
-                                    "short_desc": {
-                                        "type": "string"
-                                    },
-                                    "long_desc": {
-                                        "type": "string"
-                                    },
-                                    "additional_desc": {
-                                        "type": "object",
-                                        "properties": {
-                                            "url": {
-                                                "type": "string"
-                                            },
-                                            "content_type": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "text/plain",
-                                                    "text/html",
-                                                    "application/json"
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    "media": {
-                                        "type": "array",
-                                        "items": {
-                                            "description": "This object contains a url to a media file.",
-                                            "type": "object",
-                                            "properties": {
-                                                "mimetype": {
-                                                    "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                    "type": "string"
-                                                },
-                                                "url": {
-                                                    "description": "The URL of the file",
-                                                    "type": "string",
-                                                    "format": "uri"
-                                                },
-                                                "signature": {
-                                                    "description": "The digital signature of the file signed by the sender",
-                                                    "type": "string"
-                                                },
-                                                "dsa": {
-                                                    "description": "The signing algorithm used by the sender",
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "images": {
-                                        "type": "array",
-                                        "items": {
-                                            "description": "Describes an image",
-                                            "type": "object",
-                                            "properties": {
-                                                "url": {
-                                                    "description": "URL to the image. This can be a data url or an remote url",
-                                                    "type": "string",
-                                                    "format": "uri"
-                                                },
-                                                "size_type": {
-                                                    "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                    "type": "string",
-                                                    "enum": [
-                                                        "xs",
-                                                        "sm",
-                                                        "md",
-                                                        "lg",
-                                                        "xl",
-                                                        "custom"
-                                                    ]
-                                                },
-                                                "width": {
-                                                    "description": "Width of the image in pixels",
-                                                    "type": "string"
-                                                },
-                                                "height": {
-                                                    "description": "Height of the image in pixels",
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "tags": {
-                                "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
-                                "type": "object",
-                                "properties": {
-                                    "display": {
-                                        "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
-                                        "type": "boolean",
-                                        "default": true
-                                    },
-                                    "descriptor": {
-                                        "description": "Description of the TagGroup, can be used to store detailed information.",
-                                        "allOf": [
-                                            {
-                                                "description": "Physical description of something.",
-                                                "type": "object",
-                                                "properties": {
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "code": {
-                                                        "type": "string"
-                                                    },
-                                                    "short_desc": {
-                                                        "type": "string"
-                                                    },
-                                                    "long_desc": {
-                                                        "type": "string"
-                                                    },
-                                                    "additional_desc": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "url": {
-                                                                "type": "string"
-                                                            },
-                                                            "content_type": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "text/plain",
-                                                                    "text/html",
-                                                                    "application/json"
-                                                                ]
-                                                            }
-                                                        }
-                                                    },
-                                                    "media": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "description": "This object contains a url to a media file.",
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "mimetype": {
-                                                                    "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                                    "type": "string"
-                                                                },
-                                                                "url": {
-                                                                    "description": "The URL of the file",
-                                                                    "type": "string",
-                                                                    "format": "uri"
-                                                                },
-                                                                "signature": {
-                                                                    "description": "The digital signature of the file signed by the sender",
-                                                                    "type": "string"
-                                                                },
-                                                                "dsa": {
-                                                                    "description": "The signing algorithm used by the sender",
-                                                                    "type": "string"
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "images": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "description": "Describes an image",
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "url": {
-                                                                    "description": "URL to the image. This can be a data url or an remote url",
-                                                                    "type": "string",
-                                                                    "format": "uri"
-                                                                },
-                                                                "size_type": {
-                                                                    "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "xs",
-                                                                        "sm",
-                                                                        "md",
-                                                                        "lg",
-                                                                        "xl",
-                                                                        "custom"
-                                                                    ]
-                                                                },
-                                                                "width": {
-                                                                    "description": "Width of the image in pixels",
-                                                                    "type": "string"
-                                                                },
-                                                                "height": {
-                                                                    "description": "Height of the image in pixels",
-                                                                    "type": "string"
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    "list": {
-                                        "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
-                                        "type": "array",
-                                        "items": {
-                                            "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
-                                            "type": "object",
-                                            "properties": {
-                                                "descriptor": {
-                                                    "description": "Description of the Tag, can be used to store detailed information.",
-                                                    "allOf": [
-                                                        {
-                                                            "description": "Physical description of something.",
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "name": {
-                                                                    "type": "string"
-                                                                },
-                                                                "code": {
-                                                                    "type": "string"
-                                                                },
-                                                                "short_desc": {
-                                                                    "type": "string"
-                                                                },
-                                                                "long_desc": {
-                                                                    "type": "string"
-                                                                },
-                                                                "additional_desc": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "url": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "content_type": {
-                                                                            "type": "string",
-                                                                            "enum": [
-                                                                                "text/plain",
-                                                                                "text/html",
-                                                                                "application/json"
-                                                                            ]
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "media": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "description": "This object contains a url to a media file.",
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "mimetype": {
-                                                                                "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                                                "type": "string"
-                                                                            },
-                                                                            "url": {
-                                                                                "description": "The URL of the file",
-                                                                                "type": "string",
-                                                                                "format": "uri"
-                                                                            },
-                                                                            "signature": {
-                                                                                "description": "The digital signature of the file signed by the sender",
-                                                                                "type": "string"
-                                                                            },
-                                                                            "dsa": {
-                                                                                "description": "The signing algorithm used by the sender",
-                                                                                "type": "string"
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "images": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "description": "Describes an image",
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "url": {
-                                                                                "description": "URL to the image. This can be a data url or an remote url",
-                                                                                "type": "string",
-                                                                                "format": "uri"
-                                                                            },
-                                                                            "size_type": {
-                                                                                "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                                                "type": "string",
-                                                                                "enum": [
-                                                                                    "xs",
-                                                                                    "sm",
-                                                                                    "md",
-                                                                                    "lg",
-                                                                                    "xl",
-                                                                                    "custom"
-                                                                                ]
-                                                                            },
-                                                                            "width": {
-                                                                                "description": "Width of the image in pixels",
-                                                                                "type": "string"
-                                                                            },
-                                                                            "height": {
-                                                                                "description": "Height of the image in pixels",
-                                                                                "type": "string"
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                "value": {
-                                                    "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
-                                                    "type": "string"
-                                                },
-                                                "display": {
-                                                    "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
-                                                    "type": "boolean"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+                            }
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object"
                             }
                         }
-                    }
+                    ]
                 },
                 "credentialSchema": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object"
                             }
                         }
-                    }
+                    ]
                 },
                 "proof": {
-                    "type": "object",
-                    "description": "Cryptographic proof of the credential's authenticity",
-                    "properties": {
-                        "created": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Timestamp of when the proof was generated"
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "description": "Cryptographic proof of the credential's authenticity",
+                            "properties": {
+                                "created": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Timestamp of when the proof was generated"
+                                },
+                                "proofPurpose": {
+                                    "type": "string",
+                                    "description": "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "description": "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
+                                },
+                                "verificationMethod": {
+                                    "type": "string",
+                                    "description": "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
+                                },
+                                "proofValue": {
+                                    "type": "string",
+                                    "description": "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
+                                }
+                            }
                         },
-                        "proofPurpose": {
-                            "type": "string",
-                            "description": "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
-                        },
-                        "type": {
-                            "type": "string",
-                            "description": "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
-                        },
-                        "verificationMethod": {
-                            "type": "string",
-                            "description": "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
-                        },
-                        "proofValue": {
-                            "type": "string",
-                            "description": "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object"
+                            }
                         }
-                    }
+                    ]
                 },
                 "termsOfUse": {
-                    "type": "array",
-                    "items": {
-                        "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
-                        "type": "object",
-                        "properties": {
-                            "display": {
-                                "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
-                                "type": "boolean",
-                                "default": true
-                            },
-                            "descriptor": {
-                                "description": "Description of the TagGroup, can be used to store detailed information.",
-                                "allOf": [
-                                    {
-                                        "description": "Physical description of something.",
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {
-                                                "type": "string"
-                                            },
-                                            "code": {
-                                                "type": "string"
-                                            },
-                                            "short_desc": {
-                                                "type": "string"
-                                            },
-                                            "long_desc": {
-                                                "type": "string"
-                                            },
-                                            "additional_desc": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "url": {
-                                                        "type": "string"
-                                                    },
-                                                    "content_type": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "text/plain",
-                                                            "text/html",
-                                                            "application/json"
-                                                        ]
-                                                    }
-                                                }
-                                            },
-                                            "media": {
-                                                "type": "array",
-                                                "items": {
-                                                    "description": "This object contains a url to a media file.",
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "mimetype": {
-                                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                            "type": "string"
-                                                        },
-                                                        "url": {
-                                                            "description": "The URL of the file",
-                                                            "type": "string",
-                                                            "format": "uri"
-                                                        },
-                                                        "signature": {
-                                                            "description": "The digital signature of the file signed by the sender",
-                                                            "type": "string"
-                                                        },
-                                                        "dsa": {
-                                                            "description": "The signing algorithm used by the sender",
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            "images": {
-                                                "type": "array",
-                                                "items": {
-                                                    "description": "Describes an image",
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "url": {
-                                                            "description": "URL to the image. This can be a data url or an remote url",
-                                                            "type": "string",
-                                                            "format": "uri"
-                                                        },
-                                                        "size_type": {
-                                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                            "type": "string",
-                                                            "enum": [
-                                                                "xs",
-                                                                "sm",
-                                                                "md",
-                                                                "lg",
-                                                                "xl",
-                                                                "custom"
-                                                            ]
-                                                        },
-                                                        "width": {
-                                                            "description": "Width of the image in pixels",
-                                                            "type": "string"
-                                                        },
-                                                        "height": {
-                                                            "description": "Height of the image in pixels",
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "list": {
-                                "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
-                                "type": "array",
-                                "items": {
-                                    "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
-                                    "type": "object",
-                                    "properties": {
-                                        "descriptor": {
-                                            "description": "Description of the Tag, can be used to store detailed information.",
-                                            "allOf": [
-                                                {
-                                                    "description": "Physical description of something.",
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "code": {
-                                                            "type": "string"
-                                                        },
-                                                        "short_desc": {
-                                                            "type": "string"
-                                                        },
-                                                        "long_desc": {
-                                                            "type": "string"
-                                                        },
-                                                        "additional_desc": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "url": {
-                                                                    "type": "string"
-                                                                },
-                                                                "content_type": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "text/plain",
-                                                                        "text/html",
-                                                                        "application/json"
-                                                                    ]
-                                                                }
-                                                            }
-                                                        },
-                                                        "media": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "description": "This object contains a url to a media file.",
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "mimetype": {
-                                                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "url": {
-                                                                        "description": "The URL of the file",
-                                                                        "type": "string",
-                                                                        "format": "uri"
-                                                                    },
-                                                                    "signature": {
-                                                                        "description": "The digital signature of the file signed by the sender",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "dsa": {
-                                                                        "description": "The signing algorithm used by the sender",
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "images": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "description": "Describes an image",
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "url": {
-                                                                        "description": "URL to the image. This can be a data url or an remote url",
-                                                                        "type": "string",
-                                                                        "format": "uri"
-                                                                    },
-                                                                    "size_type": {
-                                                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "xs",
-                                                                            "sm",
-                                                                            "md",
-                                                                            "lg",
-                                                                            "xl",
-                                                                            "custom"
-                                                                        ]
-                                                                    },
-                                                                    "width": {
-                                                                        "description": "Width of the image in pixels",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "height": {
-                                                                        "description": "Height of the image in pixels",
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "value": {
-                                            "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
-                                            "type": "string"
-                                        },
-                                        "display": {
-                                            "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
-                                            "type": "boolean"
-                                        }
-                                    }
-                                }
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object"
                             }
                         }
-                    }
+                    ]
                 },
                 "credentialStatus": {
-                    "type": "array",
-                    "items": {
-                        "description": "Physical description of something.",
-                        "type": "object",
-                        "properties": {
-                            "name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
                                 "type": "string"
-                            },
-                            "code": {
-                                "type": "string"
-                            },
-                            "short_desc": {
-                                "type": "string"
-                            },
-                            "long_desc": {
-                                "type": "string"
-                            },
-                            "additional_desc": {
-                                "type": "object",
-                                "properties": {
-                                    "url": {
-                                        "type": "string"
-                                    },
-                                    "content_type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "text/plain",
-                                            "text/html",
-                                            "application/json"
-                                        ]
-                                    }
-                                }
-                            },
-                            "media": {
-                                "type": "array",
-                                "items": {
-                                    "description": "This object contains a url to a media file.",
-                                    "type": "object",
-                                    "properties": {
-                                        "mimetype": {
-                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                            "type": "string"
-                                        },
-                                        "url": {
-                                            "description": "The URL of the file",
-                                            "type": "string",
-                                            "format": "uri"
-                                        },
-                                        "signature": {
-                                            "description": "The digital signature of the file signed by the sender",
-                                            "type": "string"
-                                        },
-                                        "dsa": {
-                                            "description": "The signing algorithm used by the sender",
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            },
-                            "images": {
-                                "type": "array",
-                                "items": {
-                                    "description": "Describes an image",
-                                    "type": "object",
-                                    "properties": {
-                                        "url": {
-                                            "description": "URL to the image. This can be a data url or an remote url",
-                                            "type": "string",
-                                            "format": "uri"
-                                        },
-                                        "size_type": {
-                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                            "type": "string",
-                                            "enum": [
-                                                "xs",
-                                                "sm",
-                                                "md",
-                                                "lg",
-                                                "xl",
-                                                "custom"
-                                            ]
-                                        },
-                                        "width": {
-                                            "description": "Width of the image in pixels",
-                                            "type": "string"
-                                        },
-                                        "height": {
-                                            "description": "Height of the image in pixels",
-                                            "type": "string"
-                                        }
-                                    }
-                                }
+                            }
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object"
                             }
                         }
-                    }
+                    ]
                 },
                 "evidence": {
-                    "type": "array",
-                    "items": {
-                        "description": "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316",
-                        "type": "object",
-                        "properties": {
-                            "display": {
-                                "description": "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search.",
-                                "type": "boolean",
-                                "default": true
-                            },
-                            "descriptor": {
-                                "description": "Description of the TagGroup, can be used to store detailed information.",
-                                "allOf": [
-                                    {
-                                        "description": "Physical description of something.",
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {
-                                                "type": "string"
-                                            },
-                                            "code": {
-                                                "type": "string"
-                                            },
-                                            "short_desc": {
-                                                "type": "string"
-                                            },
-                                            "long_desc": {
-                                                "type": "string"
-                                            },
-                                            "additional_desc": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "url": {
-                                                        "type": "string"
-                                                    },
-                                                    "content_type": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "text/plain",
-                                                            "text/html",
-                                                            "application/json"
-                                                        ]
-                                                    }
-                                                }
-                                            },
-                                            "media": {
-                                                "type": "array",
-                                                "items": {
-                                                    "description": "This object contains a url to a media file.",
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "mimetype": {
-                                                            "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                            "type": "string"
-                                                        },
-                                                        "url": {
-                                                            "description": "The URL of the file",
-                                                            "type": "string",
-                                                            "format": "uri"
-                                                        },
-                                                        "signature": {
-                                                            "description": "The digital signature of the file signed by the sender",
-                                                            "type": "string"
-                                                        },
-                                                        "dsa": {
-                                                            "description": "The signing algorithm used by the sender",
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            "images": {
-                                                "type": "array",
-                                                "items": {
-                                                    "description": "Describes an image",
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "url": {
-                                                            "description": "URL to the image. This can be a data url or an remote url",
-                                                            "type": "string",
-                                                            "format": "uri"
-                                                        },
-                                                        "size_type": {
-                                                            "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                            "type": "string",
-                                                            "enum": [
-                                                                "xs",
-                                                                "sm",
-                                                                "md",
-                                                                "lg",
-                                                                "xl",
-                                                                "custom"
-                                                            ]
-                                                        },
-                                                        "width": {
-                                                            "description": "Width of the image in pixels",
-                                                            "type": "string"
-                                                        },
-                                                        "height": {
-                                                            "description": "Height of the image in pixels",
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "list": {
-                                "description": "An array of Tag objects listed under this group. This property can be set by BAPs during search to narrow the `search` and achieve more relevant results. When received during `on_search`, BAPs must render this list under the heading described by the `name` property of this schema.",
-                                "type": "array",
-                                "items": {
-                                    "description": "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service.",
-                                    "type": "object",
-                                    "properties": {
-                                        "descriptor": {
-                                            "description": "Description of the Tag, can be used to store detailed information.",
-                                            "allOf": [
-                                                {
-                                                    "description": "Physical description of something.",
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "code": {
-                                                            "type": "string"
-                                                        },
-                                                        "short_desc": {
-                                                            "type": "string"
-                                                        },
-                                                        "long_desc": {
-                                                            "type": "string"
-                                                        },
-                                                        "additional_desc": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "url": {
-                                                                    "type": "string"
-                                                                },
-                                                                "content_type": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "text/plain",
-                                                                        "text/html",
-                                                                        "application/json"
-                                                                    ]
-                                                                }
-                                                            }
-                                                        },
-                                                        "media": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "description": "This object contains a url to a media file.",
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "mimetype": {
-                                                                        "description": "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "url": {
-                                                                        "description": "The URL of the file",
-                                                                        "type": "string",
-                                                                        "format": "uri"
-                                                                    },
-                                                                    "signature": {
-                                                                        "description": "The digital signature of the file signed by the sender",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "dsa": {
-                                                                        "description": "The signing algorithm used by the sender",
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "images": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "description": "Describes an image",
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "url": {
-                                                                        "description": "URL to the image. This can be a data url or an remote url",
-                                                                        "type": "string",
-                                                                        "format": "uri"
-                                                                    },
-                                                                    "size_type": {
-                                                                        "description": "The size of the image. The network policy can define the default dimensions of each type",
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "xs",
-                                                                            "sm",
-                                                                            "md",
-                                                                            "lg",
-                                                                            "xl",
-                                                                            "custom"
-                                                                        ]
-                                                                    },
-                                                                    "width": {
-                                                                        "description": "Width of the image in pixels",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "height": {
-                                                                        "description": "Height of the image in pixels",
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "value": {
-                                            "description": "The value of the tag. This set by the BPP and rendered as-is by the BAP.",
-                                            "type": "string"
-                                        },
-                                        "display": {
-                                            "description": "This value indicates if the tag is intended for display purposes. If set to `true`, then this tag must be displayed. If it is set to `false`, it should not be displayed. This value can override the group display value.",
-                                            "type": "boolean"
-                                        }
-                                    }
-                                }
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object"
                             }
                         }
-                    }
+                    ]
+                },
+                "credentialHash": {
+                    "type": "string"
                 }
             }
         }

--- a/api/about-endpoint/becknVerifiableCredential.json
+++ b/api/about-endpoint/becknVerifiableCredential.json
@@ -263,7 +263,7 @@
             "description": "Describes a Verifiable Credential",
             "type": "object",
             "properties": {
-                "context": {
+                "@context": {
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -356,31 +356,7 @@
                 "proof": {
                     "anyOf": [
                         {
-                            "type": "object",
-                            "description": "Cryptographic proof of the credential's authenticity",
-                            "properties": {
-                                "created": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "description": "Timestamp of when the proof was generated"
-                                },
-                                "proofPurpose": {
-                                    "type": "string",
-                                    "description": "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
-                                },
-                                "type": {
-                                    "type": "string",
-                                    "description": "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
-                                },
-                                "verificationMethod": {
-                                    "type": "string",
-                                    "description": "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
-                                },
-                                "proofValue": {
-                                    "type": "string",
-                                    "description": "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
-                                }
-                            }
+                            "type": "object"
                         },
                         {
                             "type": "array",

--- a/api/about-endpoint/example.json
+++ b/api/about-endpoint/example.json
@@ -2,16 +2,15 @@
     "credentials": [
         {
             "verifiableCredential": {
+                "@context": [
+                    "https://www.w3.org/2018/credentials/v1"
+                ],
                 "type": [
                     "VerifiableCredential",
                     "UEICredential"
                 ],
-                "issuer": {
-                    "description": {
-                        "name": "did:eui:6fb1f712ebe12c27cc26eebfe11"
-                    }
-                },
-                "issueDate": "2022-01-01T19:23:24Z",
+                "issuer": "did:eui:6fb1f712ebe12c27cc26eebfe11",
+                "issuanceDate": "2022-01-01T19:23:24Z",
                 "validFrom": "2022-01-01T19:23:24Z",
                 "validUntil": "2027-01-01T19:23:24Z",
                 "credentialSubject": {
@@ -29,14 +28,16 @@
                         }
                     ]
                 },
-                "proof": {
+                "proof": [
+                    {
                     "type": "DataIntegrityProof",
                     "created": "2022-11-13T18:19:39Z",
                     "verificationMethod": "did:key:zDnaeyJCMXfq8SgtJWbcLgaJyDGY8BU6iw8rhMyqC4aYumkRu",
                     "cryptosuite": "eddsa-rdfc-2022",
                     "proofPurpose": "assertionMethod",
                     "proofValue": "z5aDaMUdSGSrAarqQCwPEbLbDTvXt2yQGeYyViiVwgWCQ14iNgXqkSWC72uVBW4Vz2y2NdNy9dvnSZkRCSNqJ7HgN"
-                }
+                    }
+                ]
             }
         }
     ],

--- a/api/about-endpoint/example.json
+++ b/api/about-endpoint/example.json
@@ -1,0 +1,44 @@
+{
+    "credentials": [
+        {
+            "verifiableCredential": {
+                "type": [
+                    "VerifiableCredential",
+                    "UEICredential"
+                ],
+                "issuer": {
+                    "description": {
+                        "name": "did:eui:6fb1f712ebe12c27cc26eebfe11"
+                    }
+                },
+                "issueDate": "2022-01-01T19:23:24Z",
+                "validFrom": "2022-01-01T19:23:24Z",
+                "validUntil": "2027-01-01T19:23:24Z",
+                "credentialSubject": {
+                    "id": "did:web:leela@pulseenergy.io",
+                    "tags": [
+                        {
+                            "descriptor": {
+                                "name": "Energy Certificate"
+                            },
+                            "list": [
+                                {
+                                    "value": "UEI Certified"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "proof": {
+                    "type": "DataIntegrityProof",
+                    "created": "2022-11-13T18:19:39Z",
+                    "verificationMethod": "did:key:zDnaeyJCMXfq8SgtJWbcLgaJyDGY8BU6iw8rhMyqC4aYumkRu",
+                    "cryptosuite": "eddsa-rdfc-2022",
+                    "proofPurpose": "assertionMethod",
+                    "proofValue": "z5aDaMUdSGSrAarqQCwPEbLbDTvXt2yQGeYyViiVwgWCQ14iNgXqkSWC72uVBW4Vz2y2NdNy9dvnSZkRCSNqJ7HgN"
+                }
+            }
+        }
+    ],
+    "layer2Config": "https:///pulseenergy.com//blob/p2p_trading.yaml"
+}

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1137,6 +1137,8 @@ components:
                 type: string
               description:
                 $ref: '#/components/schemas/Descriptor'
+              tags:
+                $ref: '#/components/schemas/TagGroup'
         claims:
           type: array
           items:

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1074,6 +1074,10 @@ components:
       description: 'Describes a credential of an entity - Person, Organization, Item, Payment etc'
       type: object
       properties:
+        id:
+          type: string
+        type:
+          type: string
         description:
           $ref: '#/components/schemas/Descriptor'
         docs:

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -366,6 +366,41 @@ paths:
       responses:
         default:
           $ref: '#/paths/~1init/post/responses/default'
+  /cred:
+    post:
+      tags:
+        - Beckn Provider Platform (BPP)
+      description: Request for credentials
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                context:
+                  allOf:
+                    - $ref: '#/components/schemas/Context'
+                    - properties:
+                        action:
+                          enum:
+                            - cred
+                      required:
+                        - action
+                message:
+                  type: object
+                  properties:
+                    creds:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/Credential'
+                  required:
+                    - creds
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: '#/paths/~1init/post/responses/default'
   /on_search:
     post:
       tags:
@@ -704,6 +739,42 @@ paths:
       responses:
         default:
           $ref: '#/paths/~1init/post/responses/default'
+  /on_cred:
+    post:
+      tags:
+        - Beckn Application Platform (BAP)
+      description: Callback for a credential request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                context:
+                  allOf:
+                    - $ref: '#/components/schemas/Context'
+                    - properties:
+                        action:
+                          enum:
+                            - on_cred
+                      required:
+                        - action
+                message:
+                  type: object
+                  properties:
+                    creds:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/Credential'
+                  required:
+                    - creds
+                error:
+                  $ref: '#/components/schemas/Error'
+              required:
+                - context
+      responses:
+        default:
+          $ref: '#/paths/~1init/post/responses/default'
 components:
   securitySchemes:
     SubscriberAuth:
@@ -1000,18 +1071,106 @@ components:
           type: string
           description: Country code as per ISO 3166-1 and ISO 3166-2 format
     Credential:
-      description: Describes a credential of an entity - Person or Organization
+      description: 'Describes a credential of an entity - Person, Organization, Item, Payment etc'
       type: object
       properties:
         id:
           type: string
         type:
+          description: 'Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. For example - a Medical License credential can have multiple types, "Professional License", "Regulatory License", "Regulatory License"'
+          type: array
+          items:
+            type: string
+        credential_category:
           type: string
-          default: VerifiableCredential
+          enum:
+            - AGENT
+            - CUSTOMER
+            - ORGANIZATION
+            - PAYMENT
+            - PROVIDER
+            - SUBSCRIBER
+            - FULFILLMENT
+            - ITEM
+            - ORDER
+            - PERSON
+        issuer:
+          type: object
+          description: Entity that issued the credential
+          properties:
+            description:
+              $ref: '#/components/schemas/Descriptor'
+            address:
+              $ref: '#/components/schemas/Address'
+            state:
+              $ref: '#/components/schemas/State'
+            city:
+              $ref: '#/components/schemas/City'
+            contact:
+              $ref: '#/components/schemas/Contact'
+            registration_number:
+              type: string
+              description: 'The registration number of the organization, if applicable.'
+            website:
+              type: string
+              format: uri
+              description: The official website of the issuing organization.
+        issueDate:
+          type: string
+          format: date-time
+          description: The date when the credential was issued.
+        expirationDate:
+          type: string
+          format: date-time
+          description: 'The expiration date of the credential, if applicable.'
+        subject:
+          properties:
+            description:
+              $ref: '#/components/schemas/Descriptor'
+            identification_number:
+              type: string
+              description: 'An official ID number of the subject, such as a national ID or passport number.'
+        claims:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
+        proof:
+          type: object
+          description: Cryptographic proof of the credential's authenticity
+          properties:
+            created:
+              type: string
+              format: date-time
+              description: Timestamp of when the proof was generated
+            proofPurpose:
+              type: string
+              description: 'This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity.'
+            type:
+              type: string
+              description: 'This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof.'
+            verificationMethod:
+              type: string
+              description: This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof.
+            proofValue:
+              type: string
+              description: This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity.
+        docs:
+          description: The Documents associated with the credential.
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        media:
+          description: The Media associated with the credential.
+          type: array
+          items:
+            $ref: '#/components/schemas/MediaFile'
         url:
           description: URL of the credential
           type: string
           format: uri
+        xinput:
+          description: A BAP can send a form which can be filled by the BAP with relevant details.
+          $ref: '#/components/schemas/XInput'
     Customer:
       description: Describes a customer buying/availing a product or a service
       type: object
@@ -1076,6 +1235,11 @@ components:
           type: string
           enum:
             - application/pdf
+            - text/plain
+            - image/jpeg
+            - video/mp4
+            - audio/wav
+            - application/zip
     Domain:
       description: 'Described the industry sector or sub-sector. The network policy should contain codes for all the industry sectors supported by the network. Domains can be created in varying levels of granularity. The granularity of a domain can be decided by the participants of the network. Too broad domains will result in irrelevant search broadcast calls to BPPs that don''t have services supporting the domain. Too narrow domains will result in a large number of registry entries for each BPP. It is recommended that network facilitators actively collaborate with various working groups and network participants to carefully choose domain codes keeping in mind relevance, performance, and opportunity cost. It is recommended that networks choose broad domains like mobility, logistics, healthcare etc, and progressively granularize them as and when the number of network participants for each domain grows large.'
       type: object
@@ -1199,6 +1363,10 @@ components:
         path:
           description: The physical path taken by the agent that can be rendered on a map. The allowed format of this property can be set by the network.
           type: string
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
         tags:
           type: array
           items:
@@ -1465,6 +1633,10 @@ components:
         recommended:
           description: Whether this item is a recommended item to a response
           type: boolean
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
         ttl:
           $ref: '#/components/schemas/Duration'
         tags:
@@ -1672,6 +1844,10 @@ components:
           description: The date-time of updated of this order
           type: string
           format: date-time
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
         xinput:
           description: Additional input required from the customer to confirm this order
           allOf:
@@ -1700,6 +1876,10 @@ components:
             - $ref: '#/components/schemas/City'
         contact:
           $ref: '#/components/schemas/Contact'
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
     Payment:
       description: 'Describes the terms of settlement between the BAP and the BPP for a single transaction. When instantiated, this object contains <ol><li>the amount that has to be settled,</li><li>The payment destination destination details</li><li>When the settlement should happen, and</li><li>A transaction reference ID</li></ol>. During a transaction, the BPP reserves the right to decide the terms of payment. However, the BAP can send its terms to the BPP first. If the BPP does not agree to those terms, it must overwrite the terms and return them to the BAP. If overridden, the BAP must either agree to the terms sent by the BPP in order to preserve the provider''s autonomy, or abort the transaction. In case of such disagreements, the BAP and the BPP can perform offline negotiations on the payment terms. Once an agreement is reached, the BAP and BPP can resume transactions.'
       type: object
@@ -1757,6 +1937,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TagGroup'
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
     Person:
       description: Describes a person as any individual
       type: object
@@ -1881,6 +2065,10 @@ components:
           type: boolean
         ttl:
           $ref: '#/components/schemas/Duration'
+        creds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
         tags:
           type: array
           items:

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1090,7 +1090,7 @@ components:
           description: URL of the credential
           type: string
           format: uri
-        vc:
+        verifiableCredential:
           $ref: '#/components/schemas/VC'
     CredentialRequest:
       description: Describes the schema used to request for a proof from an entity

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1096,13 +1096,11 @@ components:
       description: Describes the schema used to request for a proof from an entity
       type: object
       properties:
-        description:
-          $ref: '#/components/schemas/Descriptor'
         credential_purpose:
           type: object
           properties:
             purpose:
-              type: string
+              $ref: '#/components/schemas/Descriptor'
             document_examples:
               type: string
         xinput:

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1074,13 +1074,6 @@ components:
       description: 'Describes a credential of an entity - Person, Organization, Item, Payment etc'
       type: object
       properties:
-        id:
-          type: string
-        type:
-          description: 'Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.'
-          type: array
-          items:
-            type: string
         description:
           $ref: '#/components/schemas/Descriptor'
         credential_category:
@@ -1096,73 +1089,6 @@ components:
             - ITEM
             - ORDER
             - PERSON
-        issuer:
-          type: object
-          description: Entity that issued the credential
-          properties:
-            description:
-              $ref: '#/components/schemas/Descriptor'
-            address:
-              $ref: '#/components/schemas/Address'
-            state:
-              $ref: '#/components/schemas/State'
-            city:
-              $ref: '#/components/schemas/City'
-            contact:
-              $ref: '#/components/schemas/Contact'
-            registration_number:
-              type: string
-              description: 'The registration number of the organization, if applicable.'
-            website:
-              type: string
-              format: uri
-              description: The official website of the issuing organization.
-        issueDate:
-          type: string
-          format: date-time
-          description: The date when the credential was issued.
-        validFrom:
-          type: string
-          format: date-time
-          description: 'The expiration date of the credential, if applicable.'
-        validUntil:
-          type: string
-          format: date-time
-          description: 'The expiration date of the credential, if applicable.'
-        credentialSubject:
-          type: array
-          items:
-            properties:
-              id:
-                type: string
-              description:
-                $ref: '#/components/schemas/Descriptor'
-              tags:
-                $ref: '#/components/schemas/TagGroup'
-        claims:
-          type: array
-          items:
-            $ref: '#/components/schemas/TagGroup'
-        proof:
-          type: object
-          description: Cryptographic proof of the credential's authenticity
-          properties:
-            created:
-              type: string
-              format: date-time
-              description: Timestamp of when the proof was generated
-            proofPurpose:
-              type: string
-              description: 'This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity.'
-            type:
-              type: string
-              description: 'This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof.'
-            verificationMethod:
-              type: string
-              description: This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof.
-            proofValue:
-              type: string
-              description: This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity.
         docs:
           description: The Documents associated with the credential.
           type: array
@@ -1180,14 +1106,8 @@ components:
         xinput:
           description: A BAP can send a form which can be filled by the BAP with relevant details.
           $ref: '#/components/schemas/XInput'
-        termsOfUse:
-          type: array
-          items:
-            $ref: '#/components/schemas/TagGroup'
-        status:
-          type: array
-          items:
-            $ref: '#/components/schemas/Descriptor'
+        vc:
+          $ref: '#/components/schemas/VC'
     Customer:
       description: Describes a customer buying/availing a product or a service
       type: object
@@ -2386,6 +2306,95 @@ components:
           enum:
             - active
             - inactive
+    VC:
+      description: Describes a Verifiable Credential
+      type: object
+      properties:
+        id:
+          description: 'A unique identifier for the credential (e.g., UUID or URI).'
+          type: string
+        type:
+          description: 'Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.'
+          type: array
+          items:
+            type: string
+        description:
+          $ref: '#/components/schemas/Descriptor'
+        issuer:
+          type: object
+          description: Entity that issued the credential
+          properties:
+            description:
+              $ref: '#/components/schemas/Descriptor'
+            address:
+              $ref: '#/components/schemas/Address'
+            state:
+              $ref: '#/components/schemas/State'
+            city:
+              $ref: '#/components/schemas/City'
+            contact:
+              $ref: '#/components/schemas/Contact'
+            registration_number:
+              type: string
+              description: 'The registration number of the organization, if applicable.'
+            website:
+              type: string
+              format: uri
+              description: The official website of the issuing organization.
+        issueDate:
+          type: string
+          format: date-time
+          description: The date when the credential was issued.
+        validFrom:
+          type: string
+          format: date-time
+          description: 'The expiration date of the credential, if applicable.'
+        validUntil:
+          type: string
+          format: date-time
+          description: 'The expiration date of the credential, if applicable.'
+        credentialSubject:
+          type: array
+          items:
+            properties:
+              id:
+                type: string
+              description:
+                $ref: '#/components/schemas/Descriptor'
+              tags:
+                $ref: '#/components/schemas/TagGroup'
+        claims:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
+        proof:
+          type: object
+          description: Cryptographic proof of the credential's authenticity
+          properties:
+            created:
+              type: string
+              format: date-time
+              description: Timestamp of when the proof was generated
+            proofPurpose:
+              type: string
+              description: 'This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity.'
+            type:
+              type: string
+              description: 'This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof.'
+            verificationMethod:
+              type: string
+              description: This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof.
+            proofValue:
+              type: string
+              description: This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity.
+        termsOfUse:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
+        status:
+          type: array
+          items:
+            $ref: '#/components/schemas/Descriptor'
     Vehicle:
       description: 'Describes a vehicle is a device that is designed or used to transport people or cargo over land, water, air, or through space.<br>This has properties like category, capacity, make, model, size,variant,color,energy_type,registration'
       type: object

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -2391,10 +2391,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TagGroup'
-        status:
+        credentialStatus:
           type: array
           items:
             $ref: '#/components/schemas/Descriptor'
+        evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
     Vehicle:
       description: 'Describes a vehicle is a device that is designed or used to transport people or cargo over land, water, air, or through space.<br>This has properties like category, capacity, make, model, size,variant,color,energy_type,registration'
       type: object

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -1077,10 +1077,12 @@ components:
         id:
           type: string
         type:
-          description: 'Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. For example - a Medical License credential can have multiple types, "Professional License", "Regulatory License", "Regulatory License"'
+          description: 'Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.'
           type: array
           items:
             type: string
+        description:
+          $ref: '#/components/schemas/Descriptor'
         credential_category:
           type: string
           enum:
@@ -1119,17 +1121,22 @@ components:
           type: string
           format: date-time
           description: The date when the credential was issued.
-        expirationDate:
+        validFrom:
           type: string
           format: date-time
           description: 'The expiration date of the credential, if applicable.'
-        subject:
-          properties:
-            description:
-              $ref: '#/components/schemas/Descriptor'
-            identification_number:
-              type: string
-              description: 'An official ID number of the subject, such as a national ID or passport number.'
+        validUntil:
+          type: string
+          format: date-time
+          description: 'The expiration date of the credential, if applicable.'
+        credentialSubject:
+          type: array
+          items:
+            properties:
+              id:
+                type: string
+              description:
+                $ref: '#/components/schemas/Descriptor'
         claims:
           type: array
           items:
@@ -1171,6 +1178,14 @@ components:
         xinput:
           description: A BAP can send a form which can be filled by the BAP with relevant details.
           $ref: '#/components/schemas/XInput'
+        termsOfUse:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
+        status:
+          type: array
+          items:
+            $ref: '#/components/schemas/Descriptor'
     Customer:
       description: Describes a customer buying/availing a product or a service
       type: object

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -2308,11 +2308,15 @@ components:
       description: Describes a Verifiable Credential
       type: object
       properties:
+        context:
+          type: array
+          items:
+            type: string
         id:
           description: 'A unique identifier for the credential (e.g., UUID or URI).'
           type: string
         type:
-          description: 'Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.'
+          description: Types of the credential.
           type: array
           items:
             type: string
@@ -2361,10 +2365,14 @@ components:
                 $ref: '#/components/schemas/Descriptor'
               tags:
                 $ref: '#/components/schemas/TagGroup'
-        claims:
+        credentialSchema:
           type: array
           items:
-            $ref: '#/components/schemas/TagGroup'
+            properties:
+              id:
+                type: string
+              type:
+                type: string
         proof:
           type: object
           description: Cryptographic proof of the credential's authenticity

--- a/api/transaction/build/transaction.yaml
+++ b/api/transaction/build/transaction.yaml
@@ -389,12 +389,12 @@ paths:
                 message:
                   type: object
                   properties:
-                    creds:
+                    proofs:
                       type: array
                       items:
-                        $ref: '#/components/schemas/Credential'
+                        $ref: '#/components/schemas/CredentialRequest'
                   required:
-                    - creds
+                    - proofs
               required:
                 - context
                 - message
@@ -762,12 +762,12 @@ paths:
                 message:
                   type: object
                   properties:
-                    creds:
+                    proofs:
                       type: array
                       items:
                         $ref: '#/components/schemas/Credential'
                   required:
-                    - creds
+                    - proofs
                 error:
                   $ref: '#/components/schemas/Error'
               required:
@@ -1076,19 +1076,6 @@ components:
       properties:
         description:
           $ref: '#/components/schemas/Descriptor'
-        credential_category:
-          type: string
-          enum:
-            - AGENT
-            - CUSTOMER
-            - ORGANIZATION
-            - PAYMENT
-            - PROVIDER
-            - SUBSCRIBER
-            - FULFILLMENT
-            - ITEM
-            - ORDER
-            - PERSON
         docs:
           description: The Documents associated with the credential.
           type: array
@@ -1103,11 +1090,24 @@ components:
           description: URL of the credential
           type: string
           format: uri
-        xinput:
-          description: A BAP can send a form which can be filled by the BAP with relevant details.
-          $ref: '#/components/schemas/XInput'
         vc:
           $ref: '#/components/schemas/VC'
+    CredentialRequest:
+      description: Describes the schema used to request for a proof from an entity
+      type: object
+      properties:
+        description:
+          $ref: '#/components/schemas/Descriptor'
+        credential_purpose:
+          type: object
+          properties:
+            purpose:
+              type: string
+            document_examples:
+              type: string
+        xinput:
+          description: A requester can send a form which can be filled by the sender with relevant details.
+          $ref: '#/components/schemas/XInput'
     Customer:
       description: Describes a customer buying/availing a product or a service
       type: object

--- a/api/transaction/components/index.yaml
+++ b/api/transaction/components/index.yaml
@@ -147,7 +147,19 @@ paths:
       responses:
         default:
           $ref: "./io/Response.yaml"
-
+  /cred:
+    post:
+      tags:
+        - Beckn Provider Platform (BPP)
+      description: Request for credentials
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref : "./io/Cred.yaml"
+      responses:
+        default:
+          $ref: "./io/Response.yaml"
   /on_search:
     post:
       tags:
@@ -283,6 +295,19 @@ paths:
           application/json:
             schema:
               $ref: "./io/OnSupport.yaml"
+      responses:
+        default:
+          $ref: "./io/Response.yaml"
+  /on_cred:
+    post:
+      tags:
+        - Beckn Application Platform (BAP)
+      description: Callback for a credential request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "./io/OnCred.yaml"
       responses:
         default:
           $ref: "./io/Response.yaml"

--- a/api/transaction/components/io/Cred.yaml
+++ b/api/transaction/components/io/Cred.yaml
@@ -1,0 +1,23 @@
+type: object
+properties:
+  context:
+    allOf:
+      - $ref: "../../../../schema/Context.yaml"
+      - properties:
+          action:
+            enum:
+              - cred
+        required:
+          - action
+  message:
+    type: object
+    properties:
+      creds:
+        type: array
+        items:
+          $ref: "../../../../schema/Credential.yaml"
+    required:
+      - creds
+required:
+  - context
+  - message

--- a/api/transaction/components/io/Cred.yaml
+++ b/api/transaction/components/io/Cred.yaml
@@ -12,12 +12,12 @@ properties:
   message:
     type: object
     properties:
-      creds:
+      proofs:
         type: array
         items:
-          $ref: "../../../../schema/Credential.yaml"
+          $ref: "../../../../schema/CredentialRequest.yaml"
     required:
-      - creds
+      - proofs
 required:
   - context
   - message

--- a/api/transaction/components/io/OnCred.yaml
+++ b/api/transaction/components/io/OnCred.yaml
@@ -12,12 +12,12 @@ properties:
   message:
     type: object
     properties:
-      creds:
+      proofs:
         type: array
         items:
           $ref: "../../../../schema/Credential.yaml"
     required:
-      - creds
+      - proofs
   error:
     $ref: "../../../../schema/Error.yaml"
 required:

--- a/api/transaction/components/io/OnCred.yaml
+++ b/api/transaction/components/io/OnCred.yaml
@@ -1,0 +1,24 @@
+type: object
+properties:
+  context:
+    allOf:
+      - $ref: "../../../../schema/Context.yaml"
+      - properties:
+          action:
+            enum:
+              - on_cred
+        required:
+          - action
+  message:
+    type: object
+    properties:
+      creds:
+        type: array
+        items:
+          $ref: "../../../../schema/Credential.yaml"
+    required:
+      - creds
+  error:
+    $ref: "../../../../schema/Error.yaml"
+required:
+  - context

--- a/api/transaction/components/schema/index.yaml
+++ b/api/transaction/components/schema/index.yaml
@@ -46,6 +46,9 @@ Country:
 Credential:
   $ref: "../../../../schema/Credential.yaml"
 
+CredentialRequest:
+  $ref: "../../../../schema/CredentialRequest.yaml"
+
 Customer:
   $ref: "../../../../schema/Customer.yaml"
 

--- a/api/transaction/components/schema/index.yaml
+++ b/api/transaction/components/schema/index.yaml
@@ -166,6 +166,9 @@ Time:
 Tracking:
   $ref: "../../../../schema/Tracking.yaml"
 
+VC:
+  $ref: "../../../../schema/VC.yaml"
+
 Vehicle:
   $ref: "../../../../schema/Vehicle.yaml"
 

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -1,13 +1,102 @@
-description: Describes a credential of an entity - Person or Organization
+description: Describes a credential of an entity - Person, Organization, Item, Payment etc
 type: object
 properties:
   id:
+    description: A unique identifier for the credential (e.g., UUID or URI).
     type: string
   type:
+    description: Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. For example - a Medical License credential can have multiple types, "Professional License", "Regulatory License", "Regulatory License"
+    type: array
+    items:
+      type: string
+  credential_category:
     type: string
-    default: "VerifiableCredential"
+    enum:
+      - AGENT
+      - CUSTOMER
+      - ORGANIZATION
+      - PAYMENT
+      - PROVIDER
+      - SUBSCRIBER
+      - FULFILLMENT
+      - ITEM
+      - ORDER
+      - PERSON
+  issuer:
+    type: object
+    description: "Entity that issued the credential"
+    properties:
+      description:
+        $ref: "./Descriptor.yaml"
+      address:
+        $ref: "./Address.yaml"
+      state:
+        $ref: "./State.yaml"
+      city:
+        $ref: "./City.yaml"
+      contact:
+        $ref: "./Contact.yaml"
+      registration_number:
+        type: string
+        description: "The registration number of the organization, if applicable."
+      website:
+        type: string
+        format: uri
+        description: "The official website of the issuing organization."
+  issueDate:
+    type: string
+    format: date-time
+    description: "The date when the credential was issued."
+  expirationDate:
+    type: string
+    format: date-time
+    description: "The expiration date of the credential, if applicable."
+  subject: #The entity to whom the credential is issued (holder)
+    properties:
+      description:
+        $ref: "./Descriptor.yaml"
+      identification_number:
+        type: string
+        description: "An official ID number of the subject, such as a national ID or passport number."
+  claims:
+    type: array
+    items:
+      $ref: "./TagGroup.yaml"
+  proof:
+    type: object
+    description: "Cryptographic proof of the credential's authenticity"
+    properties:
+      created:
+        type: string
+        format: date-time
+        description: "Timestamp of when the proof was generated"
+      proofPurpose:
+        type: string
+        description: "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
+      type:
+        type: string
+        description: "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
+      verificationMethod:
+        type: string
+        description: "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
+      proofValue:
+        type: string
+        description: "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
+  docs:
+    description: The Documents associated with the credential.
+    type: array
+    items:
+      $ref: "./Document.yaml"
+  media:
+    description: The Media associated with the credential.
+    type: array
+    items:
+      $ref: "./MediaFile.yaml"
   url:
     description: URL of the credential
     type: string
     format: uri
+  xinput:
+    description: A BAP can send a form which can be filled by the BAP with relevant details.
+    $ref: "./XInput.yaml"
 

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -1,6 +1,10 @@
 description: Describes a credential of an entity - Person, Organization, Item, Payment etc
 type: object
 properties:
+  id:
+    type: string
+  type:
+    type: string
   description:
     $ref: "./Descriptor.yaml"
   docs:

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -65,6 +65,8 @@ properties:
           type: string
         description:
           $ref: "./Descriptor.yaml"
+        tags:
+          $ref: "./TagGroup.yaml"
   claims:
     type: array
     items:

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -5,10 +5,12 @@ properties:
     description: A unique identifier for the credential (e.g., UUID or URI).
     type: string
   type:
-    description: Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. For example - a Medical License credential can have multiple types, "Professional License", "Regulatory License", "Regulatory License"
+    description: Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.
     type: array
     items:
       type: string
+  description:
+    $ref: "./Descriptor.yaml"
   credential_category:
     type: string
     enum:
@@ -47,17 +49,22 @@ properties:
     type: string
     format: date-time
     description: "The date when the credential was issued."
-  expirationDate:
+  validFrom:
     type: string
     format: date-time
     description: "The expiration date of the credential, if applicable."
-  subject: #The entity to whom the credential is issued (holder)
-    properties:
-      description:
-        $ref: "./Descriptor.yaml"
-      identification_number:
-        type: string
-        description: "An official ID number of the subject, such as a national ID or passport number."
+  validUntil:
+    type: string
+    format: date-time
+    description: "The expiration date of the credential, if applicable."
+  credentialSubject: #things about which claims are made. Example subjects include human beings, animals, and things.
+    type: array #Expressing information related to multiple subjects in a verifiable credential is possible, for example, 2 subjcts who ar spouses and, the credential is a relationship credential.
+    items:
+      properties:
+        id:
+          type: string
+        description:
+          $ref: "./Descriptor.yaml"
   claims:
     type: array
     items:
@@ -99,4 +106,13 @@ properties:
   xinput:
     description: A BAP can send a form which can be filled by the BAP with relevant details.
     $ref: "./XInput.yaml"
+  termsOfUse:
+    type: array
+    items:
+      $ref: "./TagGroup.yaml"
+  status:
+    type: array
+    items:
+      $ref: "./Descriptor.yaml"
+
 

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -3,19 +3,6 @@ type: object
 properties:
   description:
     $ref: "./Descriptor.yaml"
-  credential_category:
-    type: string
-    enum:
-      - AGENT
-      - CUSTOMER
-      - ORGANIZATION
-      - PAYMENT
-      - PROVIDER
-      - SUBSCRIBER
-      - FULFILLMENT
-      - ITEM
-      - ORDER
-      - PERSON
   docs:
     description: The Documents associated with the credential.
     type: array
@@ -30,9 +17,6 @@ properties:
     description: URL of the credential
     type: string
     format: uri
-  xinput:
-    description: A BAP can send a form which can be filled by the BAP with relevant details.
-    $ref: "./XInput.yaml"
   vc:
     $ref: "./VC.yaml"
 

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -17,7 +17,7 @@ properties:
     description: URL of the credential
     type: string
     format: uri
-  vc:
+  verifiableCredential:
     $ref: "./VC.yaml"
 
 

--- a/schema/Credential.yaml
+++ b/schema/Credential.yaml
@@ -1,14 +1,6 @@
 description: Describes a credential of an entity - Person, Organization, Item, Payment etc
 type: object
 properties:
-  id:
-    description: A unique identifier for the credential (e.g., UUID or URI).
-    type: string
-  type:
-    description: Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.
-    type: array
-    items:
-      type: string
   description:
     $ref: "./Descriptor.yaml"
   credential_category:
@@ -24,73 +16,6 @@ properties:
       - ITEM
       - ORDER
       - PERSON
-  issuer:
-    type: object
-    description: "Entity that issued the credential"
-    properties:
-      description:
-        $ref: "./Descriptor.yaml"
-      address:
-        $ref: "./Address.yaml"
-      state:
-        $ref: "./State.yaml"
-      city:
-        $ref: "./City.yaml"
-      contact:
-        $ref: "./Contact.yaml"
-      registration_number:
-        type: string
-        description: "The registration number of the organization, if applicable."
-      website:
-        type: string
-        format: uri
-        description: "The official website of the issuing organization."
-  issueDate:
-    type: string
-    format: date-time
-    description: "The date when the credential was issued."
-  validFrom:
-    type: string
-    format: date-time
-    description: "The expiration date of the credential, if applicable."
-  validUntil:
-    type: string
-    format: date-time
-    description: "The expiration date of the credential, if applicable."
-  credentialSubject: #things about which claims are made. Example subjects include human beings, animals, and things.
-    type: array #Expressing information related to multiple subjects in a verifiable credential is possible, for example, 2 subjcts who ar spouses and, the credential is a relationship credential.
-    items:
-      properties:
-        id:
-          type: string
-        description:
-          $ref: "./Descriptor.yaml"
-        tags:
-          $ref: "./TagGroup.yaml"
-  claims:
-    type: array
-    items:
-      $ref: "./TagGroup.yaml"
-  proof:
-    type: object
-    description: "Cryptographic proof of the credential's authenticity"
-    properties:
-      created:
-        type: string
-        format: date-time
-        description: "Timestamp of when the proof was generated"
-      proofPurpose:
-        type: string
-        description: "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
-      type:
-        type: string
-        description: "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
-      verificationMethod:
-        type: string
-        description: "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
-      proofValue:
-        type: string
-        description: "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
   docs:
     description: The Documents associated with the credential.
     type: array
@@ -108,13 +33,7 @@ properties:
   xinput:
     description: A BAP can send a form which can be filled by the BAP with relevant details.
     $ref: "./XInput.yaml"
-  termsOfUse:
-    type: array
-    items:
-      $ref: "./TagGroup.yaml"
-  status:
-    type: array
-    items:
-      $ref: "./Descriptor.yaml"
+  vc:
+    $ref: "./VC.yaml"
 
 

--- a/schema/CredentialRequest.yaml
+++ b/schema/CredentialRequest.yaml
@@ -1,0 +1,23 @@
+description: Describes the schema used to request for a proof from an entity
+type: object
+properties:
+  description:
+    $ref: "./Descriptor.yaml"
+  credential_purpose:
+    type: object
+    properties:
+      purpose:
+        type: string
+        # enum:
+        #   - PROOF_OF_ADDRESS
+        #   - PROOF_OF_IDENTITY
+        #   - PROOF_OF_OWNERSHIP
+        #   - PROOF_OF_INCOME
+        #   - PROOF_OF_EDUCATION
+        #   - PROOF_OF_COMPLIANCE
+        #   - PROOF_OF_INSURANCE
+      document_examples:
+        type: string
+  xinput:
+    description: A requester can send a form which can be filled by the sender with relevant details.
+    $ref: "./XInput.yaml"

--- a/schema/CredentialRequest.yaml
+++ b/schema/CredentialRequest.yaml
@@ -1,21 +1,11 @@
 description: Describes the schema used to request for a proof from an entity
 type: object
-properties:
-  description:
-    $ref: "./Descriptor.yaml"
+properties:    
   credential_purpose:
     type: object
     properties:
       purpose:
-        type: string
-        # enum:
-        #   - PROOF_OF_ADDRESS
-        #   - PROOF_OF_IDENTITY
-        #   - PROOF_OF_OWNERSHIP
-        #   - PROOF_OF_INCOME
-        #   - PROOF_OF_EDUCATION
-        #   - PROOF_OF_COMPLIANCE
-        #   - PROOF_OF_INSURANCE
+        $ref: "./Descriptor.yaml"
       document_examples:
         type: string
   xinput:

--- a/schema/Document.yaml
+++ b/schema/Document.yaml
@@ -14,3 +14,8 @@ properties:
     type: string
     enum:
       - application/pdf
+      - text/plain
+      - image/jpeg
+      - video/mp4
+      - audio/wav
+      - application/zip

--- a/schema/Fulfillment.yaml
+++ b/schema/Fulfillment.yaml
@@ -47,6 +47,10 @@ properties:
   path:
     description: The physical path taken by the agent that can be rendered on a map. The allowed format of this property can be set by the network.
     type: string
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"
   tags:
     type: array
     items:

--- a/schema/Item.yaml
+++ b/schema/Item.yaml
@@ -105,6 +105,10 @@ properties:
   recommended:
     description: Whether this item is a recommended item to a response
     type: boolean
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"
   ttl:
     $ref: "./Duration.yaml"
   tags:

--- a/schema/Order.yaml
+++ b/schema/Order.yaml
@@ -98,6 +98,10 @@ properties:
     description: The date-time of updated of this order
     type: string
     format: date-time
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"
   xinput:
     description: Additional input required from the customer to confirm this order
     allOf:

--- a/schema/Organization.yaml
+++ b/schema/Organization.yaml
@@ -17,3 +17,7 @@ properties:
     - $ref: "./City.yaml"
   contact:
     $ref: "./Contact.yaml"
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"

--- a/schema/Payment.yaml
+++ b/schema/Payment.yaml
@@ -54,4 +54,8 @@ properties:
     type: array
     items:
       $ref: "./TagGroup.yaml"
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"
 

--- a/schema/Provider.yaml
+++ b/schema/Provider.yaml
@@ -46,6 +46,10 @@ properties:
     type: boolean
   ttl:
     $ref: "./Duration.yaml"
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"
   tags:
     type: array
     items:

--- a/schema/Subscriber.yaml
+++ b/schema/Subscriber.yaml
@@ -23,3 +23,7 @@ properties:
     description: The region of operation of this subscriber
     allOf:
       - $ref: "./Location.yaml"
+  creds:
+    type: array
+    items:
+      $ref: "./Credential.yaml"

--- a/schema/VC.yaml
+++ b/schema/VC.yaml
@@ -14,87 +14,94 @@ properties:
     items:
       type: string
   description:
-    $ref: "./Descriptor.yaml"
+    anyOf:
+      - type: string
+      - type: object
+      - type: array
+        items:
+          type: object
   issuer:
-    type: object
-    description: "Entity that issued the credential"
-    properties:
-      description:
-        $ref: "./Descriptor.yaml"
-      address:
-        $ref: "./Address.yaml"
-      state:
-        $ref: "./State.yaml"
-      city:
-        $ref: "./City.yaml"
-      contact:
-        $ref: "./Contact.yaml"
-      registration_number:
-        type: string
-        description: "The registration number of the organization, if applicable."
-      website:
-        type: string
-        format: uri
-        description: "The official website of the issuing organization."
-  issueDate:
+    anyOf:
+      - type: string
+      - type: object
+  issuanceDate:
     type: string
-    format: date-time
     description: "The date when the credential was issued."
   validFrom:
     type: string
-    format: date-time
     description: "The expiration date of the credential, if applicable."
   validUntil:
     type: string
-    format: date-time
     description: "The expiration date of the credential, if applicable."
-  credentialSubject: #things about which claims are made. Example subjects include human beings, animals, and things.
-    type: array #Expressing information related to multiple subjects in a verifiable credential is possible, for example, 2 subjcts who are spouses and, the credential is a relationship credential.
-    items:
-      properties:
-        id:
+  credentialSubject:
+    anyOf:
+      - type: string
+      - type: object
+      - type: array
+        items:
           type: string
-        description:
-          $ref: "./Descriptor.yaml"
-        tags:
-          $ref: "./TagGroup.yaml"
+      - type: array
+        items:
+          type: object
   credentialSchema:
-    type: array
-    items:
-      properties:
-        id:
-          type: string
-        type:
-          type: string
+    anyOf:
+      - type: object
+      - type: array
+        items:
+          type: object
   proof:
-    type: object
-    description: "Cryptographic proof of the credential's authenticity"
-    properties:
-      created:
-        type: string
-        format: date-time
-        description: "Timestamp of when the proof was generated"
-      proofPurpose:
-        type: string
-        description: "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
-      type:
-        type: string
-        description: "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
-      verificationMethod:
-        type: string
-        description: "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
-      proofValue:
-        type: string
-        description: "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
+    anyOf:
+      - type: object
+        description: "Cryptographic proof of the credential's authenticity"
+        properties:
+          created:
+            type: string
+            format: date-time
+            description: "Timestamp of when the proof was generated"
+          proofPurpose:
+            type: string
+            description: "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
+          type:
+            type: string
+            description: "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
+          verificationMethod:
+            type: string
+            description: "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
+          proofValue:
+            type: string
+            description: "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
+      - type: array
+        items:
+          type: object
   termsOfUse:
-    type: array
-    items:
-      $ref: "./TagGroup.yaml"
+    anyOf:
+      - type: string
+      - type: object
+      - type: array
+        items:
+          type: string
+      - type: array
+        items:
+          type: object
   credentialStatus:
-    type: array
-    items:
-      $ref: "./Descriptor.yaml"
+    anyOf:
+      - type: string
+      - type: object
+      - type: array
+        items:
+          type: string
+      - type: array
+        items:
+          type: object
   evidence: # The evidence property is used to express supporting information, such as documentary evidence, related to the verifiable credential.
-    type: array
-    items:
-      $ref: "./TagGroup.yaml"
+    anyOf:
+      - type: string
+      - type: object
+      - type: array
+        items:
+          type: string
+      - type: array
+        items:
+          type: object
+  credentialHash:
+    type: string

--- a/schema/VC.yaml
+++ b/schema/VC.yaml
@@ -1,0 +1,88 @@
+description: Describes a Verifiable Credential
+type: object
+properties:
+  id:
+    description: A unique identifier for the credential (e.g., UUID or URI).
+    type: string
+  type:
+    description: Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.
+    type: array
+    items:
+      type: string
+  description:
+    $ref: "./Descriptor.yaml"
+  issuer:
+    type: object
+    description: "Entity that issued the credential"
+    properties:
+      description:
+        $ref: "./Descriptor.yaml"
+      address:
+        $ref: "./Address.yaml"
+      state:
+        $ref: "./State.yaml"
+      city:
+        $ref: "./City.yaml"
+      contact:
+        $ref: "./Contact.yaml"
+      registration_number:
+        type: string
+        description: "The registration number of the organization, if applicable."
+      website:
+        type: string
+        format: uri
+        description: "The official website of the issuing organization."
+  issueDate:
+    type: string
+    format: date-time
+    description: "The date when the credential was issued."
+  validFrom:
+    type: string
+    format: date-time
+    description: "The expiration date of the credential, if applicable."
+  validUntil:
+    type: string
+    format: date-time
+    description: "The expiration date of the credential, if applicable."
+  credentialSubject: #things about which claims are made. Example subjects include human beings, animals, and things.
+    type: array #Expressing information related to multiple subjects in a verifiable credential is possible, for example, 2 subjcts who ar spouses and, the credential is a relationship credential.
+    items:
+      properties:
+        id:
+          type: string
+        description:
+          $ref: "./Descriptor.yaml"
+        tags:
+          $ref: "./TagGroup.yaml"
+  claims:
+    type: array
+    items:
+      $ref: "./TagGroup.yaml"
+  proof:
+    type: object
+    description: "Cryptographic proof of the credential's authenticity"
+    properties:
+      created:
+        type: string
+        format: date-time
+        description: "Timestamp of when the proof was generated"
+      proofPurpose:
+        type: string
+        description: "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
+      type:
+        type: string
+        description: "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
+      verificationMethod:
+        type: string
+        description: "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
+      proofValue:
+        type: string
+        description: "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
+  termsOfUse:
+    type: array
+    items:
+      $ref: "./TagGroup.yaml"
+  status:
+    type: array
+    items:
+      $ref: "./Descriptor.yaml"

--- a/schema/VC.yaml
+++ b/schema/VC.yaml
@@ -1,11 +1,15 @@
 description: Describes a Verifiable Credential
 type: object
 properties:
+  context:
+    type: array
+    items:
+      type: string
   id:
     description: A unique identifier for the credential (e.g., UUID or URI).
     type: string
   type:
-    description: Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.
+    description: Types of the credential.
     type: array
     items:
       type: string
@@ -54,10 +58,14 @@ properties:
           $ref: "./Descriptor.yaml"
         tags:
           $ref: "./TagGroup.yaml"
-  claims:
+  credentialSchema:
     type: array
     items:
-      $ref: "./TagGroup.yaml"
+      properties:
+        id:
+          type: string
+        type:
+          type: string
   proof:
     type: object
     description: "Cryptographic proof of the credential's authenticity"

--- a/schema/VC.yaml
+++ b/schema/VC.yaml
@@ -1,7 +1,7 @@
 description: Describes a Verifiable Credential
 type: object
 properties:
-  context:
+  '@context':
     type: array
     items:
       type: string
@@ -52,24 +52,6 @@ properties:
   proof:
     anyOf:
       - type: object
-        description: "Cryptographic proof of the credential's authenticity"
-        properties:
-          created:
-            type: string
-            format: date-time
-            description: "Timestamp of when the proof was generated"
-          proofPurpose:
-            type: string
-            description: "This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity."
-          type:
-            type: string
-            description: "This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof."
-          verificationMethod:
-            type: string
-            description: "This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof."
-          proofValue:
-            type: string
-            description: "This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity."
       - type: array
         items:
           type: object

--- a/schema/VC.yaml
+++ b/schema/VC.yaml
@@ -45,7 +45,7 @@ properties:
     format: date-time
     description: "The expiration date of the credential, if applicable."
   credentialSubject: #things about which claims are made. Example subjects include human beings, animals, and things.
-    type: array #Expressing information related to multiple subjects in a verifiable credential is possible, for example, 2 subjcts who ar spouses and, the credential is a relationship credential.
+    type: array #Expressing information related to multiple subjects in a verifiable credential is possible, for example, 2 subjcts who are spouses and, the credential is a relationship credential.
     items:
       properties:
         id:
@@ -82,7 +82,11 @@ properties:
     type: array
     items:
       $ref: "./TagGroup.yaml"
-  status:
+  credentialStatus:
     type: array
     items:
       $ref: "./Descriptor.yaml"
+  evidence: # The evidence property is used to express supporting information, such as documentary evidence, related to the verifiable credential.
+    type: array
+    items:
+      $ref: "./TagGroup.yaml"


### PR DESCRIPTION
### Description

As per the discussions, it was decided that to represent platform level credentials, we will use a beckn.json file, which will be accessed at <bpp_uri/bap_uri>/beckn.json.

Other platforms should be able to fetch this using a <bpp_uri/bap_uri>/beckn.json url.

This PR defines the schema for the beckn.json using jsonSchema.

### Summary
The current proposed schema for beckn.json has 2 fields.

**credentials**: This is an array of credentials object. The schema of each credential object in the array is same as the [Credential](https://github.com/beckn/protocol-specifications/blob/bd7d11ef224c5e648a57348a87fb25324005d5df/schema/Credential.yaml) object defined in the Beckn Core protocol specification. This array would have a list of credentials that a platform has. For example, there could be a credential to represent if a platform is UEI verified.

**layer2config**: This filed would have the link to a layer 2 config file. A Layer2 configuration file contains the network specific business rules corresponding to a network.

### Changes

1. A new folder ```api/about-endpoint``` is created.
2. A new file ```api/about-endpoint/about.json``` is created which defines the template for the beckn.json content.
3. A new file ```api/about-endpoint/becknVerifiableCredential.json``` was generated programatically using ``` json-dereference ``` cli command. This process uses the existing schema/Credential.yaml file to generate the ```api/about-endpoint/becknVerifiableCredential.json``` file.
4.  A new file ```api/about-endpoint/beckn.json``` was generated programmatically using ``` json-dereference ``` cli command. 

### Migration Impact
The changes are fully backward compatible. All modifications involved either the creation of new schemas or the addition of new fields to existing schemas.
