### PR TITLE
feat: Add state property to Order schema

### DIFF
--- a/schema/Order.yaml
+++ b/schema/Order.yaml
@@ -101,3 +101,7 @@ properties:
     type: array
     items:
       $ref: "./TagGroup.yaml"
+  state:
+    description: The current state of the order. This can represent various stages like 'Pending', 'Processing', 'Shipped', etc., as defined by the network policy.
+    allOf:
+      - $ref: "./State.yaml"


### PR DESCRIPTION
**Issue Reference** : Resolves #310 
- This PR adds a state property to the Order schema in the draft specification. The state property references the State schema and is intended to represent the current state of an order, such as 'Pending', 'Processing', or 'Shipped'.
-  This addition enhances the draft specification by providing a more granular way to track the lifecycle of an order.

**Changes Made**

- [ ] Updated [Order.yaml](https://cuddly-lamp-5gq9rp9vwgwwf765.github.dev/) to include the state property.
- [ ] The state property references the State schema (`/schema/State.yaml`).

Adding `Order.state` aligns the draft spec with the stable spec and provides better clarity on order lifecycle management.
