### PR TITLE
feat: Add fulfillment-level tracking tracking support to /trackAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,8 +182,8 @@ Schedule schema object was added to Time
 -   **/get_feedback_categories**  : Returns the allowed categories that can have a feedback
 -   **/get_feedback_form**  : Request the BPP to get a feedback form
 -   **/feedback_form**  : Get a feedback form from the BPP. Callback response of /get_feedback_form
--   **/rating**  : Uses Rating object as message
--   **/on_rating**  : Used RatingAck as message
+-   **rating**  : Uses Rating object as message
+-   **on_rating**  : Used RatingAck as message
 
 **Made all the meta APIs async. Created the following new meta BAP APIs :**
 -   POST /cancellation_reasons
@@ -246,3 +246,6 @@ The same was added to the following :
 ### December 22, 2021
 
 **Added document object array in order**
+
+### April 25, 2025
+- Updated `/track` API to support tracking at the fulfillment level by adding an optional `fulfillment_id` property.

--- a/api/transaction/components/io/Track.yaml
+++ b/api/transaction/components/io/Track.yaml
@@ -14,6 +14,8 @@ properties:
     properties:
       order_id:
         $ref: "../../../../schema/Order.yaml#/properties/id"
+      fulfillment_id:
+        $ref: "../../../../schema/Fulfillment.yaml#/properties/id"
       callback_url:
         type: string
         format: uri

--- a/schema/Item.yaml
+++ b/schema/Item.yaml
@@ -67,15 +67,26 @@ properties:
     items:
       $ref: "./RefundTerm.yaml"    
   replacement_terms:
-    description: Terms that are applicable be met when this item is replaced
+    description: Terms that are applicable when this item is replaced
     type: array
     items:
       $ref: "./ReplacementTerm.yaml"
+      properties:
+        replacement_eligible:
+          description: Indicates if the item is eligible for replacement
+          type: boolean
+        fulfillment_managed_by:
+          description: Entity managing the fulfillment of the replacement
+          type: string
   return_terms:
     description: Terms that are applicable when this item is returned
     type: array
     items:
       $ref: "./ReturnTerm.yaml"
+      properties:
+        return_eligible:
+          description: Indicates if the item is eligible for return
+          type: boolean
   xinput:
     description: Additional input required from the customer to purchase / avail this item
     allOf:

--- a/schema/Order.yaml
+++ b/schema/Order.yaml
@@ -101,3 +101,7 @@ properties:
     type: array
     items:
       $ref: "./TagGroup.yaml"
+  state:
+    description: The current state of the order. This can represent various stages like 'Pending', 'Processing', 'Shipped', etc., as defined by the network policy.
+    allOf:
+      - $ref: "./State.yaml"


### PR DESCRIPTION
**Issue Reference** : Resolves #313 
This PR introduces support for tracking at the fulfillment level in the /track API. The following changes have been made:

- **API Schema Update:**
Added an optional` fulfillment_id` property to the /track API schema to enable tracking specific fulfillments within an order.

- **Changelog Update:**
Documented the changes in the [CHANGELOG.md](https://cuddly-lamp-5gq9rp9vwgwwf765.github.dev/) file.

**Context:**
The /track API previously supported tracking only at the order level. This enhancement addresses the need for item-based fulfillments where multiple fulfillments within a single order may involve different logistics providers, each with its own tracking URL.

**Impact:**
Enables more granular tracking for use cases involving multiple fulfillments.
Backward-compatible as the `fulfillment_id `property is optional.
