### PR TITLE
feat: Changes to Item attributes in draft spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,8 +182,8 @@ Schedule schema object was added to Time
 -   **/get_feedback_categories**  : Returns the allowed categories that can have a feedback
 -   **/get_feedback_form**  : Request the BPP to get a feedback form
 -   **/feedback_form**  : Get a feedback form from the BPP. Callback response of /get_feedback_form
--   **/rating**  : Uses Rating object as message
--   **/on_rating**  : Used RatingAck as message
+-   **rating**  : Uses Rating object as message
+-   **on_rating**  : Used RatingAck as message
 
 **Made all the meta APIs async. Created the following new meta BAP APIs :**
 -   POST /cancellation_reasons
@@ -246,3 +246,6 @@ The same was added to the following :
 ### December 22, 2021
 
 **Added document object array in order**
+
+### April 25, 2025
+- Updated `/track` API to support tracking at the fulfillment level by adding an optional `fulfillment_id` property.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,14 @@
+In draft spec here, request following changes:
+
+- Move `return_eligible` to `Item.return_terms`
+- Move `replacement_eligible` to `Item.replacement_terms`
+- Add `fulfillment_managed_by` to `Item.replacement_terms`
+
+**Reason:**
+Return & replacement of items is independent of cancellation. Cancellation of a fulfillment can result in return-to-origin (RTO) if the buyer refuses to accept it, irrespective of what `return_eligible` is. On the other hand, fashion items are generally returnable while some items (that are made-to-order e.g., cake) can't be returned, hence `return_eligible` will be false.
+
+**Goals:**
+To identify the problem being addressed here and provide a solution.
+
+**Expected Outcome:**
+Recommendation for changes in the protocol specification.

--- a/api/transaction/components/io/Track.yaml
+++ b/api/transaction/components/io/Track.yaml
@@ -14,6 +14,8 @@ properties:
     properties:
       order_id:
         $ref: "../../../../schema/Order.yaml#/properties/id"
+      fulfillment_id:
+        $ref: "../../../../schema/Fulfillment.yaml#/properties/id"
       callback_url:
         type: string
         format: uri

--- a/schema/Item.yaml
+++ b/schema/Item.yaml
@@ -67,15 +67,26 @@ properties:
     items:
       $ref: "./RefundTerm.yaml"    
   replacement_terms:
-    description: Terms that are applicable be met when this item is replaced
+    description: Terms that are applicable when this item is replaced
     type: array
     items:
       $ref: "./ReplacementTerm.yaml"
+      properties:
+        replacement_eligible:
+          description: Indicates if the item is eligible for replacement
+          type: boolean
+        fulfillment_managed_by:
+          description: Entity managing the fulfillment of the replacement
+          type: string
   return_terms:
     description: Terms that are applicable when this item is returned
     type: array
     items:
       $ref: "./ReturnTerm.yaml"
+      properties:
+        return_eligible:
+          description: Indicates if the item is eligible for return
+          type: boolean
   xinput:
     description: Additional input required from the customer to purchase / avail this item
     allOf:

--- a/schema/Order.yaml
+++ b/schema/Order.yaml
@@ -101,3 +101,7 @@ properties:
     type: array
     items:
       $ref: "./TagGroup.yaml"
+  state:
+    description: The current state of the order. This can represent various stages like 'Pending', 'Processing', 'Shipped', etc., as defined by the network policy.
+    allOf:
+      - $ref: "./State.yaml"


### PR DESCRIPTION
**Issue Reference :** Resolves #321
In draft spec here, request the following changes:

- Move `return_eligible` to `Item.return_terms`
- Move `replacement_eligible` to `Item.replacement_terms`
- Add `fulfillment_managed_by` to `Item.replacement_terms`

**Reason:**
Return & replacement of items is independent of cancellation. Cancellation of a fulfillment can result in return-to-origin (RTO) if the buyer refuses to accept it, irrespective of what` return_eligible `is. On the other hand, fashion items are generally returnable while some items (that are made-to-order e.g., cake) can't be returned, hence `return_eligible` will be false.