### PR TITLE
removing the message_id from the subscribe and on_subscribe old body

### DIFF
--- a/api/registry/build/registry.yaml
+++ b/api/registry/build/registry.yaml
@@ -417,5 +417,3 @@ components:
             updated:
               type: string
               format: date-time
-            message_id:
-              type: string

--- a/schema/Subscription.yaml
+++ b/schema/Subscription.yaml
@@ -36,5 +36,3 @@ allOf:
       updated:
         type: string
         format: date-time
-      message_id:
-        type: string


### PR DESCRIPTION
##  Schema Cleanup: Removal of `message_id` from Subscribe and OnSubscribe Payloads

### Summary

This PR cleans up the **Beckn Registry Specification** by removing the obsolete `message_id` field from the older **Subscribe** and **OnSubscribe** endpoint payloads. This change simplifies the API and avoids redundancy now that correlation is handled via the `context` object.

---

### What’s Changed

#### 1. **Schema Cleanup – `message_id` Removed**
- The `message_id` field has been removed from:
  - `api/registry/components/io/Subscribe.yaml`
  - `api/registry/components/io/OnSubscribe.yaml`

#### 3. **Documentation & Build Adjustments**
- Updated:
  - Example request/response snippets to exclude `message_id` from "message" part
- Rebuilt the OpenAPI bundle:
  ```bash
  swagger-cli bundle api/registry/components/index.yaml \
    --outfile api/registry/build/registry.yaml \
    --type yaml

###  How It Was Tested

- Verified OpenAPI bundle using:
  ```bash
  swagger-cli bundle api/registry/components/index.yaml --outfile api/registry/build/registry.yaml --type yaml
